### PR TITLE
Adding [Serializable] attribute to geometry3Sharp objects to allow Bi…

### DIFF
--- a/approximation/BiArcFit2.cs
+++ b/approximation/BiArcFit2.cs
@@ -9,7 +9,7 @@ namespace g3
 	// 2D Biarc fitting ported from http://www.ryanjuckett.com/programming/biarc-interpolation/
 	//
 	//
-    public class BiArcFit2
+   [Serializable] public class BiArcFit2
     {
         public Vector2d Point1;
         public Vector2d Point2;

--- a/approximation/GaussPointsFit3.cs
+++ b/approximation/GaussPointsFit3.cs
@@ -9,7 +9,7 @@ namespace g3
     // extents are the eigenvalues of the covariance matrix and are returned in
     // increasing order.  The quantites are stored in a Box3<Real> just to have a
     // single container.
-    public class GaussPointsFit3
+   [Serializable] public class GaussPointsFit3
     {
         public Box3d Box;
         public bool ResultValid = false;

--- a/approximation/OrthogonalPlaneFit3.cs
+++ b/approximation/OrthogonalPlaneFit3.cs
@@ -6,7 +6,7 @@ namespace g3
     // Ported from WildMagic5 Wm5ApprPlaneFit3
     // Least-squares fit of a plane to (x,y,z) data by using distance measurements
     // orthogonal to the proposed plane.
-    public class OrthogonalPlaneFit3
+   [Serializable] public class OrthogonalPlaneFit3
     {
         public Vector3d Origin;
         public Vector3d Normal;

--- a/color/ColorHSV.cs
+++ b/color/ColorHSV.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class ColorHSV
+   [Serializable] public class ColorHSV
     {
         public float h;
         public float s;

--- a/color/ColorMap.cs
+++ b/color/ColorMap.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public class ColorMap
+   [Serializable] public class ColorMap
     {
         struct ColorPoint
         {

--- a/color/Colorb.cs
+++ b/color/Colorb.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Colorb
+    [Serializable] public struct Colorb
     {
         public byte r;
         public byte g;

--- a/color/Colorf.cs
+++ b/color/Colorf.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Colorf : IComparable<Colorf>, IEquatable<Colorf>
+    [Serializable] public struct Colorf : IComparable<Colorf>, IEquatable<Colorf>
     {
         public float r;
         public float g;

--- a/comp_geom/Arrangement2d.cs
+++ b/comp_geom/Arrangement2d.cs
@@ -18,7 +18,7 @@ namespace g3
     /// [TODO] maybe smarter handling
     /// 
     /// </summary>
-    public class Arrangement2d
+   [Serializable] public class Arrangement2d
     {
         // graph of arrangement
         public DGraph2 Graph;

--- a/comp_geom/ConvexHull2.cs
+++ b/comp_geom/ConvexHull2.cs
@@ -26,7 +26,7 @@ namespace g3
     /// 
     /// HullIndices provides ordered indices of vertices of input points that form hull.
     /// </summary>
-    public class ConvexHull2
+   [Serializable] public class ConvexHull2
     {
         //QueryNumberType mQueryType = QueryNumberType.QT_DOUBLE;
         IList<Vector2d> mVertices;

--- a/comp_geom/GraphCells2d.cs
+++ b/comp_geom/GraphCells2d.cs
@@ -17,7 +17,7 @@ namespace g3
     /// oriented clockwise, if converted to a Polygon2d.
     /// 
     /// </summary>
-    public class GraphCells2d
+   [Serializable] public class GraphCells2d
     {
         public DGraph2 Graph;
 

--- a/comp_geom/GraphSplitter2d.cs
+++ b/comp_geom/GraphSplitter2d.cs
@@ -15,7 +15,7 @@ namespace g3
     ///   - computation of signs for a split-line is currently O(N). If inserting many
     ///     parallel lines, can improve this using standard sorting.
     /// </summary>
-    public class GraphSplitter2d
+   [Serializable] public class GraphSplitter2d
     {
         public DGraph2 Graph;
 

--- a/comp_geom/SphericalFibonacciPointSet.cs
+++ b/comp_geom/SphericalFibonacciPointSet.cs
@@ -15,7 +15,7 @@ namespace g3
     /// 
     /// math from http://lgdv.cs.fau.de/uploads/publications/spherical_fibonacci_mapping_opt.pdf
     /// </summary>
-    public class SphericalFibonacciPointSet
+   [Serializable] public class SphericalFibonacciPointSet
     {
         public int N = 64;
 

--- a/containment/ContBox3.cs
+++ b/containment/ContBox3.cs
@@ -9,7 +9,7 @@ namespace g3
 
     // ported from GTEngine GteContOrientedBox3.h
     // (2017) url: https://www.geometrictools.com/GTEngine/Include/Mathematics/GteContOrientedBox3.h
-    public class ContOrientedBox3
+   [Serializable] public class ContOrientedBox3
     {
         public Box3d Box;
         public bool ResultValid = false;

--- a/containment/ContMinBox2.cs
+++ b/containment/ContMinBox2.cs
@@ -15,7 +15,7 @@ namespace g3
     /// <summary>
     /// Fit minimal bounding-box to a set of 2D points. Result is in MinBox.
     /// </summary>
-    public class ContMinBox2
+   [Serializable] public class ContMinBox2
     {
         Box2d mMinBox;
 

--- a/containment/ContMinCircle2.cs
+++ b/containment/ContMinCircle2.cs
@@ -14,7 +14,7 @@ namespace g3
     /// <summary>
     /// Fit minimal bounding-circle to a set of 2D points 
     /// </summary>
-    public class ContMinCircle2
+   [Serializable] public class ContMinCircle2
     {
         double mEpsilon;
         Func<int, int[], Support, Circle>[] mUpdate = new Func<int, int[], Support, Circle>[4];

--- a/core/BufferUtil.cs
+++ b/core/BufferUtil.cs
@@ -14,7 +14,7 @@ namespace g3
     ///    - byte[] conversions
     ///    - zlib compress/decompress byte[] buffers
     /// </summary>
-    public class BufferUtil
+   [Serializable] public class BufferUtil
     {
         static public void SetVertex3(double[] v, int i, double x, double y, double z) {
             v[3 * i] = x;
@@ -561,7 +561,7 @@ namespace g3
     ///    T * ptr = &array[i];
     ///    ptr[k] = value
     /// </summary>
-    public struct ArrayAlias<T>
+    [Serializable] public struct ArrayAlias<T>
     {
         public T[] Source;
         public int Index;

--- a/core/CommandArgumentSet.cs
+++ b/core/CommandArgumentSet.cs
@@ -7,7 +7,7 @@ namespace g3
 {
     // this is a utility class for parsing command-line arguments, but can
     // also be used for other things (eg like constructing command-line arguments!)
-    public class CommandArgumentSet
+   [Serializable] public class CommandArgumentSet
     {
         // expectation is that these arguments will appear as like
         //  -samples 7   or -output /some/kind/of/path

--- a/core/DVector.cs
+++ b/core/DVector.cs
@@ -11,7 +11,7 @@ namespace g3
     //   - this[] operator does not check bounds, so it can write to any valid Block
     //   - some fns discard Blocks beyond iCurBlock
     //   - wtf...
-    public class DVector<T> : IEnumerable<T>
+   [Serializable] public class DVector<T> : IEnumerable<T>
     {
         List<T[]> Blocks;
         int iCurBlock;
@@ -408,7 +408,7 @@ namespace g3
 
 
         // block iterator
-        public struct DBlock
+        [Serializable] public struct DBlock
         {
             public T[] data;
             public int usedCount;

--- a/core/DVectorArray.cs
+++ b/core/DVectorArray.cs
@@ -10,7 +10,7 @@ namespace g3
     // This class is just a wrapper around a dvector that provides convenient 3-element set/get access
     // Useful for things like treating a float array as a list of vectors
     //
-    public class DVectorArray3<T> : IEnumerable<T>
+   [Serializable] public class DVectorArray3<T> : IEnumerable<T>
     {
         public DVector<T> vector;
 
@@ -67,7 +67,7 @@ namespace g3
     }
 
 
-    public class DVectorArray3d : DVectorArray3<double>
+   [Serializable] public class DVectorArray3d : DVectorArray3<double>
     {
         const double invalid_value = -99999999.0;
 
@@ -87,7 +87,7 @@ namespace g3
     };
 
 
-    public class DVectorArray3f : DVectorArray3<float>
+   [Serializable] public class DVectorArray3f : DVectorArray3<float>
     {
         public DVectorArray3f(int nCount = 0) : base(nCount) { }
         public DVectorArray3f(float[] data) : base(data) { }
@@ -104,7 +104,7 @@ namespace g3
     };
 
 
-    public class DVectorArray3i : DVectorArray3<int>
+   [Serializable] public class DVectorArray3i : DVectorArray3<int>
     {
         public DVectorArray3i(int nCount = 0) : base(nCount) { }
         public DVectorArray3i(int[] data) : base(data) { }
@@ -133,7 +133,7 @@ namespace g3
 
 
 
-    public class DIndexArray3i : DVectorArray3<int>
+   [Serializable] public class DIndexArray3i : DVectorArray3<int>
     {
         public DIndexArray3i(int nCount = 0) : base(nCount) { }
         public DIndexArray3i(int[] data) : base(data) { }
@@ -167,7 +167,7 @@ namespace g3
     //
     // Same as DVectorArray3, but for 2D vectors/etc
     //
-    public class DVectorArray2<T> : IEnumerable<T>
+   [Serializable] public class DVectorArray2<T> : IEnumerable<T>
     {
         public DVector<T> vector;
 
@@ -217,7 +217,7 @@ namespace g3
             return this.GetEnumerator();
         }
     }
-    public class DVectorArray2d : DVectorArray2<double>
+   [Serializable] public class DVectorArray2d : DVectorArray2<double>
     {
         public DVectorArray2d(int nCount = 0) : base(nCount) { }
         public DVectorArray2d(double[] data) : base(data) { }
@@ -231,7 +231,7 @@ namespace g3
                 yield return this[i];
         }
     };
-    public class DVectorArray2f : DVectorArray2<float>
+   [Serializable] public class DVectorArray2f : DVectorArray2<float>
     {
         public DVectorArray2f(int nCount = 0) : base(nCount) { }
         public DVectorArray2f(float[] data) : base(data) { }
@@ -248,7 +248,7 @@ namespace g3
 
 
 
-    public class DIndexArray2i : DVectorArray2<int>
+   [Serializable] public class DIndexArray2i : DVectorArray2<int>
     {
         public DIndexArray2i(int nCount = 0) : base(nCount) { }
         public DIndexArray2i(int[] data) : base(data) { }

--- a/core/DijkstraGraphDistance.cs
+++ b/core/DijkstraGraphDistance.cs
@@ -17,7 +17,7 @@ namespace g3
     ///   - MeshVertices(mesh) - compute on vertices of mesh
     /// 
     /// </summary>
-    public class DijkstraGraphDistance
+   [Serializable] public class DijkstraGraphDistance
     {
         public const float InvalidValue = float.MaxValue;
 

--- a/core/DynamicPriorityQueue.cs
+++ b/core/DynamicPriorityQueue.cs
@@ -33,7 +33,7 @@ namespace g3
     /// 
     /// conceptually based on https://github.com/BlueRaja/High-Speed-Priority-Queue-for-C-Sharp
     /// </summary>
-    public class DynamicPriorityQueue<T> : IEnumerable<T>
+   [Serializable] public class DynamicPriorityQueue<T> : IEnumerable<T>
         where T : DynamicPriorityQueueNode
     {
         // set this to true during development to catch issues

--- a/core/HBitArray.cs
+++ b/core/HBitArray.cs
@@ -16,7 +16,7 @@ namespace g3
     /// Uses more memory than BitArray, but each tree level is divided by 32, so
     /// it is better than NlogN
     /// </summary>
-    public class HBitArray : IEnumerable<int>
+   [Serializable] public class HBitArray : IEnumerable<int>
     {
         struct MyBitVector32
         {

--- a/core/HashUtil.cs
+++ b/core/HashUtil.cs
@@ -9,7 +9,7 @@ namespace g3
     /// 
     /// (should probably be using uint? but standard GetHashCode() returns int...)
     /// </summary>
-    public struct HashBuilder
+    [Serializable] public struct HashBuilder
     {
         public int Hash;
 

--- a/core/IndexPriorityQueue.cs
+++ b/core/IndexPriorityQueue.cs
@@ -17,7 +17,7 @@ namespace g3
     /// 
     /// conceptually based on https://github.com/BlueRaja/High-Speed-Priority-Queue-for-C-Sharp
     /// </summary>
-    public class IndexPriorityQueue : IEnumerable<int>
+   [Serializable] public class IndexPriorityQueue : IEnumerable<int>
     {
         // set this to true during development to catch issues
         public bool EnableDebugChecks = false;

--- a/core/Indexing.cs
+++ b/core/Indexing.cs
@@ -8,7 +8,7 @@ namespace g3
 
     // An enumerator that enumerates over integers [start, start+count)
     // (useful when you need to do things like iterate over indices of an array rather than values)
-    public class IndexRangeEnumerator : IEnumerable<int>
+   [Serializable] public class IndexRangeEnumerator : IEnumerable<int>
     {
         int Start = 0;
         int Count = 0;
@@ -27,7 +27,7 @@ namespace g3
 
 
     // Add true/false operator[] to integer HashSet
-    public class IndexHashSet : HashSet<int>
+   [Serializable] public class IndexHashSet : HashSet<int>
     {
         public bool this[int key]
         {
@@ -51,7 +51,7 @@ namespace g3
     /// use a HashSet (or perhaps some other DS) if the fraction of the index space 
     /// required is small
     /// </summary>
-    public class IndexFlagSet : IEnumerable<int>
+   [Serializable] public class IndexFlagSet : IEnumerable<int>
     {
         BitArray bits;
         HashSet<int> hash;
@@ -165,7 +165,7 @@ namespace g3
 
 
 	// i = i index map
-	public class IdentityIndexMap : IIndexMap
+	[Serializable] public class IdentityIndexMap : IIndexMap
 	{
 		public int this[int index] {
 			get { return index; }
@@ -174,7 +174,7 @@ namespace g3
 
 
 	// i = i + constant index map
-	public class ShiftIndexMap : IIndexMap
+	[Serializable] public class ShiftIndexMap : IIndexMap
 	{
 		public int Shift;
 
@@ -189,7 +189,7 @@ namespace g3
 
 
 	// i = constant index map
-	public class ConstantIndexMap : IIndexMap
+	[Serializable] public class ConstantIndexMap : IIndexMap
 	{
 		public int Constant;
 
@@ -205,7 +205,7 @@ namespace g3
 
 
     // dense or sparse index map
-	public class IndexMap : IIndexMap
+	[Serializable] public class IndexMap : IIndexMap
     {
         // this is returned if sparse map doesn't contain value
         public readonly int InvalidIndex = int.MinValue;

--- a/core/MemoryPool.cs
+++ b/core/MemoryPool.cs
@@ -6,7 +6,7 @@ namespace g3
 	/// <summary>
 	/// Very basic object pool class. 
 	/// </summary>
-	public class MemoryPool<T> where T : class, new()
+	[Serializable] public class MemoryPool<T> where T : class, new()
 	{
         DVector<T> Allocated;
         DVector<T> Free;

--- a/core/ProfileUtil.cs
+++ b/core/ProfileUtil.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace g3
 {
 
-    public class BlockTimer
+   [Serializable] public class BlockTimer
     {
         public Stopwatch Watch;
         public string Label;
@@ -71,7 +71,7 @@ namespace g3
 
 
 
-    public class LocalProfiler : IDisposable
+   [Serializable] public class LocalProfiler : IDisposable
     {
         Dictionary<string, BlockTimer> Timers = new Dictionary<string, BlockTimer>();
         List<string> Order = new List<string>();

--- a/core/ProgressCancel.cs
+++ b/core/ProgressCancel.cs
@@ -14,7 +14,7 @@ namespace g3
     /// <summary>
     /// Just wraps a func<bool> as an ICancelSource
     /// </summary>
-    public class CancelFunction : ICancelSource
+   [Serializable] public class CancelFunction : ICancelSource
     {
         public Func<bool> CancelF;
         public CancelFunction(Func<bool> cancelF) {
@@ -29,7 +29,7 @@ namespace g3
     ///  1) provide progress info back to caller (not implemented yet)
     ///  2) allow caller to cancel the computation
     /// </summary>
-    public class ProgressCancel
+   [Serializable] public class ProgressCancel
     {
         public ICancelSource Source;
 

--- a/core/RefCountVector.cs
+++ b/core/RefCountVector.cs
@@ -14,7 +14,7 @@ namespace g3
     /// No overflow checking is done in release builds.
     /// 
     /// </summary>
-    public class RefCountVector : System.Collections.IEnumerable
+   [Serializable] public class RefCountVector : System.Collections.IEnumerable
     {
         public static readonly short invalid = -1;
 

--- a/core/SafeCollections.cs
+++ b/core/SafeCollections.cs
@@ -11,7 +11,7 @@ namespace g3
     /// A simple wrapper around a List<T> that supports multi-threaded construction.
     /// Basically intended for use within things like a Parallel.ForEach
     /// </summary>
-    public class SafeListBuilder<T>
+   [Serializable] public class SafeListBuilder<T>
     {
         public List<T> List;
         public SpinLock spinlock;

--- a/core/SmallListSet.cs
+++ b/core/SmallListSet.cs
@@ -15,7 +15,7 @@ namespace g3
     /// Each list stores its count, so list-size operations are constant time.
     /// All the internal "pointers" are 32-bit.
     /// </summary>
-    public class SmallListSet
+   [Serializable] public class SmallListSet
     {
         const int Null = -1;
 

--- a/core/Snapping.cs
+++ b/core/Snapping.cs
@@ -2,7 +2,7 @@
 
 namespace g3
 {
-    public class Snapping
+   [Serializable] public class Snapping
     {
 
         public static double SnapToIncrement(double fValue, double fIncrement, double offset = 0)

--- a/core/SparseList.cs
+++ b/core/SparseList.cs
@@ -12,7 +12,7 @@ namespace g3
     /// 
     /// Currently uses Dictionary<> as sparse data structure
     /// </summary>
-    public class SparseList<T>  where T : IEquatable<T>
+   [Serializable] public class SparseList<T>  where T : IEquatable<T>
     {
         T[] dense;
         Dictionary<int, T> sparse;
@@ -115,7 +115,7 @@ namespace g3
     /// 
     /// TODO: can we combine these classes somehow?
     /// </summary>
-    public class SparseObjectList<T>  where T : class
+   [Serializable] public class SparseObjectList<T>  where T : class
     {
         T[] dense;
         Dictionary<int, T> sparse;

--- a/core/TagSet.cs
+++ b/core/TagSet.cs
@@ -7,7 +7,7 @@ namespace g3
     /// <summary>
     /// Basic object->integer mapping
     /// </summary>
-    public class IntTagSet<T>
+   [Serializable] public class IntTagSet<T>
     {
         public const int InvalidTag = int.MaxValue;
 
@@ -46,7 +46,7 @@ namespace g3
     /// <summary>
     /// integer type/value pair, packed into 32 bits - 8 for type, 24 for value
     /// </summary>
-    public struct IntTagPair
+    [Serializable] public struct IntTagPair
     {
         public byte type;
         public int value; 
@@ -69,7 +69,7 @@ namespace g3
     /// <summary>
     /// Basic object->string mapping
     /// </summary>
-    public class StringTagSet<T>
+   [Serializable] public class StringTagSet<T>
     {
         public const string InvalidTag = "";
 

--- a/core/Util.cs
+++ b/core/Util.cs
@@ -9,7 +9,7 @@ using System.IO;
 namespace g3
 {
 
-    public enum FailMode { DebugAssert, gDevAssert, Throw, ReturnOnly }
+   [Serializable] public enum FailMode { DebugAssert, gDevAssert, Throw, ReturnOnly }
 
 
     public static class Util
@@ -272,7 +272,7 @@ namespace g3
 
 
 
-    public class gException : Exception
+   [Serializable] public class gException : Exception
     {
         public gException(string sMessage) 
             : base(sMessage)

--- a/core/VectorArray.cs
+++ b/core/VectorArray.cs
@@ -10,7 +10,7 @@ namespace g3
     // This class is just a wrapper around a static array that provides convenient 3-element set/get access
     // Useful for things like treating a float array as a list of vectors
     //
-    public class VectorArray3<T> : IEnumerable<T>
+   [Serializable] public class VectorArray3<T> : IEnumerable<T>
     {
         public T[] array;
 
@@ -56,7 +56,7 @@ namespace g3
     }
 
 
-    public class VectorArray3d : VectorArray3<double>
+   [Serializable] public class VectorArray3d : VectorArray3<double>
     {
         const double invalid_value = -99999999.0;
 
@@ -92,7 +92,7 @@ namespace g3
     };
 
 
-    public class VectorArray3f : VectorArray3<float>
+   [Serializable] public class VectorArray3f : VectorArray3<float>
     {
         public VectorArray3f(int nCount) : base(nCount) { }
         public VectorArray3f(float[] data) : base(data) { }
@@ -109,7 +109,7 @@ namespace g3
     };
 
 
-    public class VectorArray3i : VectorArray3<int>
+   [Serializable] public class VectorArray3i : VectorArray3<int>
     {
         public VectorArray3i(int nCount) : base(nCount) { }
         public VectorArray3i(int[] data) : base(data) { }
@@ -138,7 +138,7 @@ namespace g3
 
 
 
-    public class IndexArray3i : VectorArray3<int>
+   [Serializable] public class IndexArray3i : VectorArray3<int>
     {
         public IndexArray3i(int nCount) : base(nCount) { }
         public IndexArray3i(int[] data) : base(data) { }
@@ -172,7 +172,7 @@ namespace g3
     //
     // Same as VectorArray3, but for 2D vectors/etc
     //
-    public class VectorArray2<T> : IEnumerable<T>
+   [Serializable] public class VectorArray2<T> : IEnumerable<T>
     {
         public T[] array;
 
@@ -217,7 +217,7 @@ namespace g3
             return array.GetEnumerator();
         }
     }
-    public class VectorArray2d : VectorArray2<double>
+   [Serializable] public class VectorArray2d : VectorArray2<double>
     {
         public VectorArray2d(int nCount) : base(nCount) { }
         public VectorArray2d(double[] data) : base(data) { }
@@ -231,7 +231,7 @@ namespace g3
                 yield return this[i];
         }
     };
-    public class VectorArray2f : VectorArray2<float>
+   [Serializable] public class VectorArray2f : VectorArray2<float>
     {
         public VectorArray2f(int nCount) : base(nCount) { }
         public VectorArray2f(float[] data) : base(data) { }
@@ -248,7 +248,7 @@ namespace g3
 
 
 
-    public class IndexArray2i : VectorArray2<int>
+   [Serializable] public class IndexArray2i : VectorArray2<int>
     {
         public IndexArray2i(int nCount) : base(nCount) { }
         public IndexArray2i(int[] data) : base(data) { }
@@ -273,7 +273,7 @@ namespace g3
 
 
 
-    public class VectorArray4<T> : IEnumerable<T>
+   [Serializable] public class VectorArray4<T> : IEnumerable<T>
     {
         public T[] array;
 
@@ -324,7 +324,7 @@ namespace g3
 
 
 
-    public class IndexArray4i : VectorArray4<int>
+   [Serializable] public class IndexArray4i : VectorArray4<int>
     {
         public IndexArray4i(int nCount) : base(nCount) { }
         public IndexArray4i(int[] data) : base(data) { }

--- a/core/g3Iterators.cs
+++ b/core/g3Iterators.cs
@@ -12,7 +12,7 @@ namespace g3
     /// <summary>
     /// Iterator that just returns a constant value N times
     /// </summary>
-    public class ConstantItr<T> : IEnumerable<T>
+   [Serializable] public class ConstantItr<T> : IEnumerable<T>
     {
         public T ConstantValue = default(T);
         public int N;
@@ -31,7 +31,7 @@ namespace g3
     /// <summary>
     /// Iterator that re-maps iterated values via a Func
     /// </summary>
-    public class RemapItr<T,T2> : IEnumerable<T>
+   [Serializable] public class RemapItr<T,T2> : IEnumerable<T>
     {
         public IEnumerable<T2> OtherItr;
         public Func<T2, T> ValueF;
@@ -52,7 +52,7 @@ namespace g3
     /// <summary>
     /// IList wrapper that remaps values via a Func (eg for index maps)
     /// </summary>
-    public class MappedList : IList<int>
+   [Serializable] public class MappedList : IList<int>
     {
         public IList<int> BaseList;
         public Func<int, int> MapF = (i) => { return i; };
@@ -98,7 +98,7 @@ namespace g3
     /// <summary>
     /// IList wrapper for an Interval1i, ie sequential list of integers
     /// </summary>
-    public struct IntSequence : IList<int>
+    [Serializable] public struct IntSequence : IList<int>
     {
         Interval1i range;
 

--- a/core/gParallel.cs
+++ b/core/gParallel.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace g3
 {
-    public class gParallel
+   [Serializable] public class gParallel
     {
 
         public static void ForEach_Sequential<T>(IEnumerable<T> source, Action<T> body)
@@ -148,7 +148,7 @@ namespace g3
     //
     // Perhaps an alternative would be to use a fixed buffer of T?
     // However, if T is a class (eg by-reference), then this doesn't help as they still have to be allocated....
-    public class ParallelStream<V, T>
+   [Serializable] public class ParallelStream<V, T>
     {
         public Func<V, T> ProducerF = null;
         //public List<Action<T>> Operators = new List<Action<T>>();
@@ -232,7 +232,7 @@ namespace g3
 
 
     // locking queue - provides thread-safe sequential add/remove/count to Queue<T>
-    public class LockingQueue<T>
+   [Serializable] public class LockingQueue<T>
     {
         Queue<T> queue;
         object queue_lock;
@@ -282,7 +282,7 @@ namespace g3
      * Note that this is class and SpinLock is a struct, so this may cause
      * disasters, but at least things build...
      */
-    public class SpinLock
+   [Serializable] public class SpinLock
     {
         object o;
         public SpinLock()

--- a/curve/Arc2.cs
+++ b/curve/Arc2.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace g3 {
 
-	public class Arc2d : IParametricCurve2d
+	[Serializable] public class Arc2d : IParametricCurve2d
 	{
 		public Vector2d Center;
 		public double Radius;

--- a/curve/ArcLengthParam.cs
+++ b/curve/ArcLengthParam.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace g3
 {
-    public struct CurveSample
+    [Serializable] public struct CurveSample
     {
         public Vector3d position;
         public Vector3d tangent;
@@ -21,7 +21,7 @@ namespace g3
 
 
 
-    public class SampledArcLengthParam : IArcLengthParam
+   [Serializable] public class SampledArcLengthParam : IArcLengthParam
     {
         double[] arc_len;
         Vector3d[] positions;
@@ -97,7 +97,7 @@ namespace g3
 
 
 
-    public struct CurveSample2d
+    [Serializable] public struct CurveSample2d
     {
         public Vector2d position;
         public Vector2d tangent;
@@ -115,7 +115,7 @@ namespace g3
     }
 
 
-    public class SampledArcLengthParam2d : IArcLengthParam2d
+   [Serializable] public class SampledArcLengthParam2d : IArcLengthParam2d
     {
         double[] arc_len;
         Vector2d[] positions;

--- a/curve/BSplineBasis.cs
+++ b/curve/BSplineBasis.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // ported from WildMagic5 BSplineBasis
-    public class BSplineBasis
+   [Serializable] public class BSplineBasis
     {
         // Defaultructor.  The number of control points is n+1 and the
         // indices i for the control points satisfy 0 <= i <= n.  The degree of

--- a/curve/BezierCurve2.cs
+++ b/curve/BezierCurve2.cs
@@ -9,7 +9,7 @@ namespace g3
     /// 2D Bezier curve of arbitrary degree
     /// Ported from WildMagic5 Wm5BezierCurve2
     /// </summary>
-    public class BezierCurve2 : BaseCurve2, IParametricCurve2d
+   [Serializable] public class BezierCurve2 : BaseCurve2, IParametricCurve2d
     {
         int mDegree;
         int mNumCtrlPoints;

--- a/curve/Circle2.cs
+++ b/curve/Circle2.cs
@@ -2,7 +2,7 @@
 
 namespace g3
 {
-    public class Circle2d : IParametricCurve2d
+   [Serializable] public class Circle2d : IParametricCurve2d
     {
 		public Vector2d Center;
 		public double Radius;

--- a/curve/CurveResampler.cs
+++ b/curve/CurveResampler.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class CurveResampler
+   [Serializable] public class CurveResampler
     {
 
         double[] lengths;

--- a/curve/CurveUtils.cs
+++ b/curve/CurveUtils.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class CurveUtils
+   [Serializable] public class CurveUtils
     {
 
         public static Vector3d GetTangent(List<Vector3d> vertices, int i, bool bLoop = false)
@@ -205,7 +205,7 @@ namespace g3
     /// <summary>
     /// Simple sampled-curve wrapper type
     /// </summary>
-    public class IWrappedCurve3d : ISampledCurve3d
+   [Serializable] public class IWrappedCurve3d : ISampledCurve3d
     {
         public IList<Vector3d> VertexList;
         public bool Closed { get; set; }

--- a/curve/DCurve3.cs
+++ b/curve/DCurve3.cs
@@ -9,7 +9,7 @@ namespace g3
     /// DCurve3 is a 3D polyline, either open or closed (via .Closed)
     /// Despite the D prefix, it is *not* dynamic
     /// </summary>
-    public class DCurve3 : ISampledCurve3d
+   [Serializable] public class DCurve3 : ISampledCurve3d
     {
         // [TODO] use dvector? or double-indirection indexing?
         //   question is how to insert efficiently...

--- a/curve/DGraph.cs
+++ b/curve/DGraph.cs
@@ -336,7 +336,7 @@ namespace g3
 
 
 
-        public struct EdgeSplitInfo
+        [Serializable] public struct EdgeSplitInfo
         {
             public int vNew;
             public int eNewBN;      // new edge [vNew,vB] (original was AB)
@@ -391,7 +391,7 @@ namespace g3
 
 
 
-        public struct EdgeCollapseInfo
+        [Serializable] public struct EdgeCollapseInfo
         {
             public int vKept;
             public int vRemoved;
@@ -531,7 +531,7 @@ namespace g3
 
 
 
-        public enum FailMode { DebugAssert, gDevAssert, Throw, ReturnOnly }
+       [Serializable] public enum FailMode { DebugAssert, gDevAssert, Throw, ReturnOnly }
 
         /// <summary>
         // This function checks that the graph is well-formed, ie all internal data
@@ -634,7 +634,7 @@ namespace g3
     /// Implementation of DGraph that has no dimensionality, ie no data
     /// stored for vertieces besides indices. 
     /// </summary>
-    public class DGraphN : DGraph
+   [Serializable] public class DGraphN : DGraph
     {
         public int AppendVertex()
         {

--- a/curve/DGraph2.cs
+++ b/curve/DGraph2.cs
@@ -12,7 +12,7 @@ namespace g3
     /// Each vertex can be connected to an arbitrary number of edges.
     /// Each vertex can have a 3-float color, and edge edge can have an integer GroupID
     /// </summary>
-	public class DGraph2 : DGraph
+	[Serializable] public class DGraph2 : DGraph
     {
 		public static readonly Vector2d InvalidVertex = new Vector2d(Double.MaxValue, 0);
 

--- a/curve/DGraph2Resampler.cs
+++ b/curve/DGraph2Resampler.cs
@@ -8,7 +8,7 @@ namespace g3
     /// <summary>
     /// "Remesher" for DGraph2 
     /// </summary>
-    public class DGraph2Resampler
+   [Serializable] public class DGraph2Resampler
     {
         public DGraph2 Graph;
 

--- a/curve/DGraph2Util.cs
+++ b/curve/DGraph2Util.cs
@@ -14,7 +14,7 @@ namespace g3
     {
 
 
-        public class Curves
+       [Serializable] public class Curves
         {
             public List<Polygon2d> Loops;
             public List<PolyLine2d> Paths;

--- a/curve/DGraph3.cs
+++ b/curve/DGraph3.cs
@@ -12,7 +12,7 @@ namespace g3
     /// Each vertex can be connected to an arbitrary number of edges.
     /// Each vertex can have a 3-float color, and edge edge can have an integer GroupID
     /// </summary>
-    public class DGraph3 : DGraph
+   [Serializable] public class DGraph3 : DGraph
 	{
 
 		public static readonly Vector3d InvalidVertex = new Vector3d(Double.MaxValue, 0, 0);

--- a/curve/DGraph3Util.cs
+++ b/curve/DGraph3Util.cs
@@ -12,7 +12,7 @@ namespace g3
     /// </summary>
     public static class DGraph3Util
     {
-        public struct Curves
+        [Serializable] public struct Curves
         {
             public List<DCurve3> Loops;
             public List<DCurve3> Paths;

--- a/curve/Ellipse2.cs
+++ b/curve/Ellipse2.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // ported from WildMagic5 Ellipse2
-    public class Ellipse2d : IParametricCurve2d
+   [Serializable] public class Ellipse2d : IParametricCurve2d
     {
         // An ellipse has center K, axis directions U[0] and U[1] (both
         // unit-length vectors), and extents e[0] and e[1] (both positive

--- a/curve/EllipseArc2.cs
+++ b/curve/EllipseArc2.cs
@@ -22,7 +22,7 @@ namespace g3 {
 	//   on two concentric circles w/ radii of major/minor axes. Possibly that is what
 	//   the formula in SampleT is doing?
 	//
-	public class EllipseArc2d : IParametricCurve2d
+	[Serializable] public class EllipseArc2d : IParametricCurve2d
 	{
 		public Vector2d Center;
 		public Vector2d Axis0, Axis1;

--- a/curve/GeneralPolygon2d.cs
+++ b/curve/GeneralPolygon2d.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 
 namespace g3 
 {
-	public class GeneralPolygon2d : IDuplicatable<GeneralPolygon2d>
+	[Serializable] public class GeneralPolygon2d : IDuplicatable<GeneralPolygon2d>
 	{
 		Polygon2d outer;
 		bool bOuterIsCW;

--- a/curve/Hexagon2.cs
+++ b/curve/Hexagon2.cs
@@ -2,7 +2,7 @@
 
 namespace g3
 {
-    public class Hexagon2d
+   [Serializable] public class Hexagon2d
     {
 		public enum TopModes
 		{

--- a/curve/LaplacianCurveDeformer.cs
+++ b/curve/LaplacianCurveDeformer.cs
@@ -12,7 +12,7 @@ namespace g3
     /// Currently only supports uniform weights (in Initialize)
     /// 
     /// </summary>
-    public class LaplacianCurveDeformer
+   [Serializable] public class LaplacianCurveDeformer
     {
         public DCurve3 Curve;
 
@@ -35,7 +35,7 @@ namespace g3
         double[] MLx, MLy, MLz;
 
         // constraints
-        public struct SoftConstraintV
+        [Serializable] public struct SoftConstraintV
         {
             public Vector3d Position;
             public double Weight;

--- a/curve/NURBSCurve2.cs
+++ b/curve/NURBSCurve2.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace g3
 {
     // ported from WildMagic5 NURBSCurve2
-    public class NURBSCurve2 : BaseCurve2, IParametricCurve2d
+   [Serializable] public class NURBSCurve2 : BaseCurve2, IParametricCurve2d
     {
         // Construction and destruction. Internal copies of the
         // input arrays are made, so to dynamically change control points,
@@ -253,7 +253,7 @@ namespace g3
         // derivatives. It will stop at the highest derivative you request.
         // More efficient than calling single-value functions above, which
         // would repeat lots of calculations
-        public struct CurveDerivatives
+        [Serializable] public struct CurveDerivatives
         {
             public Vector2d p, d1, d2, d3;
             public bool bPosition, bDer1, bDer2, bDer3;

--- a/curve/ParametricCurveSequence2.cs
+++ b/curve/ParametricCurveSequence2.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 
 namespace g3 
 {
-	public class ParametricCurveSequence2 : IParametricCurve2d, IMultiCurve2d
+	[Serializable] public class ParametricCurveSequence2 : IParametricCurve2d, IMultiCurve2d
 	{
 
 		List<IParametricCurve2d> curves;

--- a/curve/PlanarComplex.cs
+++ b/curve/PlanarComplex.cs
@@ -5,13 +5,13 @@ using System.Diagnostics;
 namespace g3 
 {
 
-	public struct ComplexSegment2d
+	[Serializable] public struct ComplexSegment2d
 	{
 		public Segment2d seg;
 		public bool isClosed;
 		public PlanarComplex.Element element;
 	}
-	public struct ComplexEndpoint2d
+	[Serializable] public struct ComplexEndpoint2d
 	{
 		public Vector2d v;
 		public bool isStart;
@@ -19,7 +19,7 @@ namespace g3
 	}
 
 
-	public class PlanarComplex 
+	[Serializable] public class PlanarComplex 
 	{
 		// these determine pointwise sampling rates
 		public double DistanceAccuracy = 0.1;
@@ -57,7 +57,7 @@ namespace g3
             public abstract Element Clone();
 		}
 
-		public class SmoothCurveElement : Element 
+		[Serializable] public class SmoothCurveElement : Element 
 		{
 			public PolyLine2d polyLine;
 
@@ -76,7 +76,7 @@ namespace g3
             }
 		}
 
-		public class SmoothLoopElement : Element 
+		[Serializable] public class SmoothLoopElement : Element 
 		{
 			public Polygon2d polygon;
 
@@ -411,13 +411,13 @@ namespace g3
 
 
 
-        public class GeneralSolid
+       [Serializable] public class GeneralSolid
         {
             public Element Outer;
             public List<Element> Holes = new List<Element>();
         }
 
-        public class SolidRegionInfo
+       [Serializable] public class SolidRegionInfo
         {
             public List<GeneralPolygon2d> Polygons;
             public List<PlanarSolid2d> Solids;
@@ -459,7 +459,7 @@ namespace g3
 
 
 
-		public struct FindSolidsOptions
+		[Serializable] public struct FindSolidsOptions
 		{
 			public double SimplifyDeviationTolerance;
 			public bool WantCurveSolids;
@@ -761,7 +761,7 @@ namespace g3
 
 
 
-		public class ClosedLoopsInfo
+		[Serializable] public class ClosedLoopsInfo
 		{
 			public List<Polygon2d> Polygons;
 			public List<IParametricCurve2d> Loops;
@@ -820,7 +820,7 @@ namespace g3
 
 
 
-		public class OpenCurvesInfo
+		[Serializable] public class OpenCurvesInfo
 		{
 			public List<PolyLine2d> Polylines;
 			public List<IParametricCurve2d> Curves;

--- a/curve/PlanarSolid2d.cs
+++ b/curve/PlanarSolid2d.cs
@@ -11,7 +11,7 @@ namespace g3
     //
     // So, it is strongly recommended that this be constructed alongside a GeneralPolygon2d,
     // which can be used for checking everything.
-	public class PlanarSolid2d 
+	[Serializable] public class PlanarSolid2d 
 	{
 		IParametricCurve2d outer;
 		//bool bOuterIsCW;

--- a/curve/PolyLine2d.cs
+++ b/curve/PolyLine2d.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace g3
 {
-	public class PolyLine2d : IEnumerable<Vector2d>
+	[Serializable] public class PolyLine2d : IEnumerable<Vector2d>
 	{
 		protected List<Vector2d> vertices;
 		public int Timestamp;
@@ -384,7 +384,7 @@ namespace g3
     /// <summary>
     /// Wrapper for a PolyLine2d that provides minimal IParametricCurve2D interface
     /// </summary>
-    public class PolyLine2DCurve : IParametricCurve2d
+   [Serializable] public class PolyLine2DCurve : IParametricCurve2d
     {
         public PolyLine2d Polyline;
 

--- a/curve/PolyLine2f.cs
+++ b/curve/PolyLine2f.cs
@@ -7,16 +7,16 @@ namespace g3
 	/// <summary>
 	/// Summary description for PolyLine.
 	/// </summary>
-	public class DPolyLine2f
+	[Serializable] public class DPolyLine2f
 	{
-		public struct Edge {
+		[Serializable] public struct Edge {
 			public int v1;
 			public int v2;
 
 			public Edge( int vertex1, int vertex2 ) {v1 = vertex1; v2 = vertex2;}
 		}
 
-		public struct Vertex {
+		[Serializable] public struct Vertex {
 			public int index;
 			public float x;
 			public float y;

--- a/curve/PolyLine3d.cs
+++ b/curve/PolyLine3d.cs
@@ -5,7 +5,7 @@ using System.Collections.ObjectModel;
 
 namespace g3
 {
-	public class PolyLine3d : IEnumerable<Vector3d>
+	[Serializable] public class PolyLine3d : IEnumerable<Vector3d>
 	{
 		protected List<Vector3d> vertices;
 		public int Timestamp;

--- a/curve/PolySimplification2.cs
+++ b/curve/PolySimplification2.cs
@@ -25,7 +25,7 @@ namespace g3
     /// [TODO] 2d variant of variational shape segmentation?
     /// 
     /// </summary>
-    public class PolySimplification2
+   [Serializable] public class PolySimplification2
     {
         List<Vector2d> Vertices;
         bool IsLoop;

--- a/curve/Polygon2d.cs
+++ b/curve/Polygon2d.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace g3
 {
-	public class Polygon2d : IDuplicatable<Polygon2d>
+	[Serializable] public class Polygon2d : IDuplicatable<Polygon2d>
     {
         protected List<Vector2d> vertices;
 		public int Timestamp;
@@ -793,7 +793,7 @@ namespace g3
     /// <summary>
     /// Wrapper for a Polygon2d that provides minimal IParametricCurve2D interface
     /// </summary>
-    public class Polygon2DCurve : IParametricCurve2d
+   [Serializable] public class Polygon2DCurve : IParametricCurve2d
     {
         public Polygon2d Polygon;
 

--- a/curve/PolygonFont2d.cs
+++ b/curve/PolygonFont2d.cs
@@ -11,9 +11,9 @@ namespace g3
     /// Each font is a list of GeneralPolygon2D objects, so each outline may have 1 or more holes.
     /// (In fact, the mapping is [string,list_of_gpolygons], so you can actually keep entire strings together if desired)
     /// </summary>
-    public class PolygonFont2d
+   [Serializable] public class PolygonFont2d
     {
-        public class CharacterInfo
+       [Serializable] public class CharacterInfo
         {
             public GeneralPolygon2d[] Polygons;
             public AxisAlignedBox2d Bounds;

--- a/curve/SculptCurveDeformers.cs
+++ b/curve/SculptCurveDeformers.cs
@@ -52,7 +52,7 @@ namespace g3
         }
 
 
-        public struct DeformInfo
+        [Serializable] public struct DeformInfo
         {
             public bool bNoChange;
             public double maxEdgeLenSqr;
@@ -74,7 +74,7 @@ namespace g3
 
 
 
-    public class StandardSculptCurveDeformation : SculptCurveDeformation
+   [Serializable] public class StandardSculptCurveDeformation : SculptCurveDeformation
     {
         // Deformation function. 
         // Arguments are curve index and weight "t" value in range [0,1]
@@ -186,7 +186,7 @@ namespace g3
 
 
     // just apply smoothing pass from standard op
-    public class SculptCurveSmooth : StandardSculptCurveDeformation
+   [Serializable] public class SculptCurveSmooth : StandardSculptCurveDeformation
     {
         public SculptCurveSmooth()
         {
@@ -199,7 +199,7 @@ namespace g3
 
 
 
-    public class SculptCurveMove : StandardSculptCurveDeformation
+   [Serializable] public class SculptCurveMove : StandardSculptCurveDeformation
     {
 
         public SculptCurveMove()

--- a/curve/SimpleCurveDeformers.cs
+++ b/curve/SimpleCurveDeformers.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 
-    public class InPlaceIterativeCurveSmooth
+   [Serializable] public class InPlaceIterativeCurveSmooth
     {
         DCurve3 _curve;
         public DCurve3 Curve {
@@ -101,7 +101,7 @@ namespace g3
 
 
 
-    public class ArcLengthSoftTranslation
+   [Serializable] public class ArcLengthSoftTranslation
     {
         DCurve3 _curve;
         public DCurve3 Curve {

--- a/distance/DistLine2Line2.cs
+++ b/distance/DistLine2Line2.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistLine2Line2
+	[Serializable] public class DistLine2Line2
 	{
 		Line2d line1;
 		public Line2d Line

--- a/distance/DistLine2Segment2.cs
+++ b/distance/DistLine2Segment2.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistLine2Segment2
+	[Serializable] public class DistLine2Segment2
 	{
 		Line2d line;
 		public Line2d Line

--- a/distance/DistLine3Ray3.cs
+++ b/distance/DistLine3Ray3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistLine3Ray3
+   [Serializable] public class DistLine3Ray3
     {
         Line3d line;
         public Line3d Line

--- a/distance/DistLine3Segment3.cs
+++ b/distance/DistLine3Segment3.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistLine3Segment3
+	[Serializable] public class DistLine3Segment3
 	{
 		Line3d line;
 		public Line3d Line

--- a/distance/DistLine3Triangle3.cs
+++ b/distance/DistLine3Triangle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistLine3Triangle3
+   [Serializable] public class DistLine3Triangle3
     {
         Line3d line;
         public Line3d Line

--- a/distance/DistPoint2Box2.cs
+++ b/distance/DistPoint2Box2.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5's DistPoint2Box2
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint2Box2
+   [Serializable] public class DistPoint2Box2
     {
         Vector2d point;
         public Vector2d Point

--- a/distance/DistPoint2Circle2.cs
+++ b/distance/DistPoint2Circle2.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5's  DistPoint3Circle3  (didn't have point2circle2)
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint2Circle2
+   [Serializable] public class DistPoint2Circle2
     {
         Vector2d point;
         public Vector2d Point

--- a/distance/DistPoint3Circle3.cs
+++ b/distance/DistPoint3Circle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint3Circle3
+   [Serializable] public class DistPoint3Circle3
     {
         Vector3d point;
         public Vector3d Point

--- a/distance/DistPoint3Cylinder3.cs
+++ b/distance/DistPoint3Cylinder3.cs
@@ -15,7 +15,7 @@ namespace g3
     //
     // DistanceSquared is always positive!!
     //
-    public class DistPoint3Cylinder3
+   [Serializable] public class DistPoint3Cylinder3
     {
         Vector3d point;
         public Vector3d Point

--- a/distance/DistPoint3Triangle3.cs
+++ b/distance/DistPoint3Triangle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistPoint3Triangle3
+   [Serializable] public class DistPoint3Triangle3
     {
         Vector3d point;
         public Vector3d Point

--- a/distance/DistRay3Ray3.cs
+++ b/distance/DistRay3Ray3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistRay3Ray3
+   [Serializable] public class DistRay3Ray3
     {
         Ray3d ray1;
         public Ray3d Ray1

--- a/distance/DistRay3Segment3.cs
+++ b/distance/DistRay3Segment3.cs
@@ -9,7 +9,7 @@ namespace g3
     /// Distance between ray and segment
     /// ported from WildMagic5
     /// </summary>
-    public class DistRay3Segment3
+   [Serializable] public class DistRay3Segment3
     {
         Ray3d ray;
         public Ray3d Ray

--- a/distance/DistSegment2Segment2.cs
+++ b/distance/DistSegment2Segment2.cs
@@ -8,7 +8,7 @@ namespace g3
 	// ported from WildMagic 5 
 	// https://www.geometrictools.com/Downloads/Downloads.html
 
-	public class DistSegment2Segment2
+	[Serializable] public class DistSegment2Segment2
 	{
 		Segment2d segment0;
 		public Segment2d Segment1

--- a/distance/DistSegment3Triangle3.cs
+++ b/distance/DistSegment3Triangle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // ported from WildMagic 5 
     // https://www.geometrictools.com/Downloads/Downloads.html
 
-    public class DistSegment3Triangle3
+   [Serializable] public class DistSegment3Triangle3
     {
         Segment3d segment;
         public Segment3d Segment

--- a/distance/DistTriangle3Triangle3.cs
+++ b/distance/DistTriangle3Triangle3.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class DistTriangle3Triangle3
+   [Serializable] public class DistTriangle3Triangle3
     {
         Triangle3d triangle0;
         public Triangle3d Triangle0

--- a/implicit/CachingGridImplicit3d.cs
+++ b/implicit/CachingGridImplicit3d.cs
@@ -15,7 +15,7 @@ namespace g3
     /// via GridOrigin, but does not support scaling or rotation. If you need those,
     /// you can wrap this in something that does the xform.
     /// </summary>
-	public class CachingDenseGridTrilinearImplicit : BoundedImplicitFunction3d
+	[Serializable] public class CachingDenseGridTrilinearImplicit : BoundedImplicitFunction3d
     {
         public DenseGrid3f Grid;
         public double CellSize;

--- a/implicit/CachingMeshSDF.cs
+++ b/implicit/CachingMeshSDF.cs
@@ -45,7 +45,7 @@ namespace g3
     /// Original license was public domain. 
     /// Permission granted by Christopher Batty to include C# port under Boost license.
     /// </summary>
-    public class CachingMeshSDF
+   [Serializable] public class CachingMeshSDF
     {
         public DMesh3 Mesh;
         public DMeshAABBTree3 Spatial;
@@ -70,7 +70,7 @@ namespace g3
         // Parity count is basically mesh winding number, handles overlap shells and
         // self-intersections, but inverted shells are 'subtracted', and inverted faces are a disaster.
         // Both modes handle internal cavities, neither handles open sheets.
-        public enum InsideModes
+       [Serializable] public enum InsideModes
         {
             CrossingCount = 0,
             ParityCount = 1
@@ -414,7 +414,7 @@ namespace g3
     /// via GridOrigin, but does not support scaling or rotation. If you need those,
     /// you can wrap this in something that does the xform.
     /// </summary>
-	public class CachingMeshSDFImplicit : BoundedImplicitFunction3d
+	[Serializable] public class CachingMeshSDFImplicit : BoundedImplicitFunction3d
     {
         public CachingMeshSDF SDF;
         public double CellSize;

--- a/implicit/FalloffFunctions.cs
+++ b/implicit/FalloffFunctions.cs
@@ -26,7 +26,7 @@ namespace gs
     /// <summary>
     /// returns 1 in range [0,ConstantRange], and then falls off to 0 in range [ConstantRange,1]
     /// </summary>
-    public class LinearFalloff : IFalloffFunction
+   [Serializable] public class LinearFalloff : IFalloffFunction
     {
         public double ConstantRange = 0;
 
@@ -53,7 +53,7 @@ namespace gs
     /// <summary>
     /// returns 1 in range [0,ConstantRange], and then falls off to 0 in range [ConstantRange,1]
     /// </summary>
-    public class WyvillFalloff : IFalloffFunction
+   [Serializable] public class WyvillFalloff : IFalloffFunction
     {
         public double ConstantRange = 0;
 

--- a/implicit/GridImplicits3d.cs
+++ b/implicit/GridImplicits3d.cs
@@ -10,7 +10,7 @@ namespace g3
     /// via GridOrigin, but does not support scaling or rotation. If you need those,
     /// you can wrap this in something that does the xform.
     /// </summary>
-	public class DenseGridTrilinearImplicit : BoundedImplicitFunction3d
+	[Serializable] public class DenseGridTrilinearImplicit : BoundedImplicitFunction3d
     {
         public DenseGrid3f Grid;
         public double CellSize;

--- a/implicit/Implicit2d.cs
+++ b/implicit/Implicit2d.cs
@@ -23,7 +23,7 @@ namespace g3
 
 
 
-	public class ImplicitPoint2d : ImplicitField2d 
+	[Serializable] public class ImplicitPoint2d : ImplicitField2d 
 	{
         Vector2f m_vCenter;
 		private float m_radius;

--- a/implicit/Implicit3d.cs
+++ b/implicit/Implicit3d.cs
@@ -26,7 +26,7 @@ namespace g3
 	/// <summary>
 	/// Implicit sphere, where zero isocontour is at Radius
 	/// </summary>
-	public class ImplicitSphere3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitSphere3d : BoundedImplicitFunction3d
     {
 		public Vector3d Origin;
 		public double Radius;
@@ -46,7 +46,7 @@ namespace g3
 	/// <summary>
 	/// Implicit half-space. "Inside" is opposite of Normal direction.
 	/// </summary>
-	public class ImplicitHalfSpace3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitHalfSpace3d : BoundedImplicitFunction3d
 	{
 		public Vector3d Origin;
 		public Vector3d Normal;
@@ -67,7 +67,7 @@ namespace g3
 	/// <summary>
 	/// Implicit axis-aligned box
 	/// </summary>
-	public class ImplicitAxisAlignedBox3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitAxisAlignedBox3d : BoundedImplicitFunction3d
 	{
 		public AxisAlignedBox3d AABox;
 
@@ -87,7 +87,7 @@ namespace g3
 	/// <summary>
 	/// Implicit oriented box
 	/// </summary>
-	public class ImplicitBox3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitBox3d : BoundedImplicitFunction3d
 	{
 		Box3d box;
 		AxisAlignedBox3d local_aabb;
@@ -123,7 +123,7 @@ namespace g3
 	/// <summary>
 	/// Implicit tube around line segment
 	/// </summary>
-	public class ImplicitLine3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitLine3d : BoundedImplicitFunction3d
 	{
 		public Segment3d Segment;
 		public double Radius;
@@ -151,7 +151,7 @@ namespace g3
 	/// Offset the zero-isocontour of an implicit function.
 	/// Assumes that negative is inside, if not, reverse offset.
 	/// </summary>
-	public class ImplicitOffset3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitOffset3d : BoundedImplicitFunction3d
 	{
 		public BoundedImplicitFunction3d A;
 		public double Offset;
@@ -177,7 +177,7 @@ namespace g3
     /// field, this converts single isocontour into two nested isocontours
     /// with zeros at interval a and b, with 'inside' in interval
     /// </summary>
-    public class ImplicitShell3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitShell3d : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d A;
         public Interval1d Inside;
@@ -209,7 +209,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class ImplicitUnion3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitUnion3d : BoundedImplicitFunction3d
 	{
 		public BoundedImplicitFunction3d A;
 		public BoundedImplicitFunction3d B;
@@ -234,7 +234,7 @@ namespace g3
 	/// Assumption is that both have surface at zero isocontour and 
 	/// negative is inside.
 	/// </summary>
-	public class ImplicitIntersection3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitIntersection3d : BoundedImplicitFunction3d
 	{
 		public BoundedImplicitFunction3d A;
 		public BoundedImplicitFunction3d B;
@@ -260,7 +260,7 @@ namespace g3
 	/// Assumption is that both have surface at zero isocontour and 
 	/// negative is inside.
 	/// </summary>
-	public class ImplicitDifference3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitDifference3d : BoundedImplicitFunction3d
 	{
 		public BoundedImplicitFunction3d A;
 		public BoundedImplicitFunction3d B;
@@ -285,7 +285,7 @@ namespace g3
 	/// Assumption is that both have surface at zero isocontour and 
 	/// negative is inside.
 	/// </summary>
-	public class ImplicitNaryUnion3d : BoundedImplicitFunction3d
+	[Serializable] public class ImplicitNaryUnion3d : BoundedImplicitFunction3d
 	{
 		public List<BoundedImplicitFunction3d> Children;
 
@@ -316,7 +316,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class ImplicitNaryIntersection3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitNaryIntersection3d : BoundedImplicitFunction3d
     {
         public List<BoundedImplicitFunction3d> Children;
 
@@ -349,7 +349,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class ImplicitNaryDifference3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitNaryDifference3d : BoundedImplicitFunction3d
 	{
 		public BoundedImplicitFunction3d A;
 		public List<BoundedImplicitFunction3d> BSet;
@@ -381,7 +381,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class ImplicitSmoothUnion3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitSmoothUnion3d : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d A;
         public BoundedImplicitFunction3d B;
@@ -408,7 +408,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class ImplicitSmoothIntersection3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitSmoothIntersection3d : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d A;
         public BoundedImplicitFunction3d B;
@@ -436,7 +436,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class ImplicitSmoothDifference3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitSmoothDifference3d : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d A;
         public BoundedImplicitFunction3d B;
@@ -463,7 +463,7 @@ namespace g3
     /// Blend of two implicit surfaces. Assumes surface is at zero iscontour.
     /// Uses Pasko blend from http://www.hyperfun.org/F-rep.pdf
     /// </summary>
-    public class ImplicitBlend3d : BoundedImplicitFunction3d
+   [Serializable] public class ImplicitBlend3d : BoundedImplicitFunction3d
 	{
 		public BoundedImplicitFunction3d A;
 		public BoundedImplicitFunction3d B;
@@ -537,7 +537,7 @@ namespace g3
     /// the distance=0 isocontour lying just before midway in
     /// the range (at the .ZeroIsocontour constant)
     /// </summary>
-    public class DistanceFieldToSkeletalField : BoundedImplicitFunction3d
+   [Serializable] public class DistanceFieldToSkeletalField : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d DistanceField;
         public double FalloffDistance;
@@ -572,7 +572,7 @@ namespace g3
     /// <summary>
     /// sum-blend
     /// </summary>
-    public class SkeletalBlend3d : BoundedImplicitFunction3d
+   [Serializable] public class SkeletalBlend3d : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d A;
         public BoundedImplicitFunction3d B;
@@ -596,7 +596,7 @@ namespace g3
     /// <summary>
     /// Ricci blend
     /// </summary>
-    public class SkeletalRicciBlend3d : BoundedImplicitFunction3d
+   [Serializable] public class SkeletalRicciBlend3d : BoundedImplicitFunction3d
     {
         public BoundedImplicitFunction3d A;
         public BoundedImplicitFunction3d B;
@@ -632,7 +632,7 @@ namespace g3
     /// Assumption is that both have surface at zero isocontour and 
     /// negative is inside.
     /// </summary>
-    public class SkeletalRicciNaryBlend3d : BoundedImplicitFunction3d
+   [Serializable] public class SkeletalRicciNaryBlend3d : BoundedImplicitFunction3d
     {
         public List<BoundedImplicitFunction3d> Children;
         public double BlendPower = 2.0;

--- a/implicit/ImplicitFieldSampler3d.cs
+++ b/implicit/ImplicitFieldSampler3d.cs
@@ -8,7 +8,7 @@ namespace g3
     /// <summary>
     /// Sample implicit fields into a dense grid
     /// </summary>
-    public class ImplicitFieldSampler3d
+   [Serializable] public class ImplicitFieldSampler3d
     {
         public DenseGrid3f Grid;
         public double CellSize;
@@ -19,7 +19,7 @@ namespace g3
         public float BackgroundValue;
 
 
-        public enum CombineModes
+       [Serializable] public enum CombineModes
         {
             DistanceMinUnion = 0
         }

--- a/implicit/MarchingQuads.cs
+++ b/implicit/MarchingQuads.cs
@@ -9,7 +9,7 @@ namespace g3
     /// [TODO] this is very, very old code. Should at minimum rewrite using current
     /// vector classes/etc.
 	/// </summary>
-	public class MarchingQuads
+	[Serializable] public class MarchingQuads
 	{
 		DPolyLine2f m_stroke;
 

--- a/intersection/Intersector1.cs
+++ b/intersection/Intersector1.cs
@@ -11,7 +11,7 @@ namespace g3
 	//
     // [TODO] could this be struct? is not used in contexts where we necessarily need a new object...
     //
-	public class Intersector1 
+	[Serializable] public class Intersector1 
 	{
 		// intervals to intersect
 		public Interval1d U;

--- a/intersection/IntrLine2Line2.cs
+++ b/intersection/IntrLine2Line2.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
 	// ported from WildMagic5 
-	public class IntrLine2Line2
+	[Serializable] public class IntrLine2Line2
     {
         Line2d line1;
         public Line2d Line1

--- a/intersection/IntrLine2Segment2.cs
+++ b/intersection/IntrLine2Segment2.cs
@@ -33,7 +33,7 @@ namespace g3
     //   q = int.MaxValue:  The line/segment are collinear.  Type is Segment.
 
 
-    public class IntrLine2Segment2
+   [Serializable] public class IntrLine2Segment2
     {
         Line2d line;
         public Line2d Line {

--- a/intersection/IntrLine2Triangle2.cs
+++ b/intersection/IntrLine2Triangle2.cs
@@ -3,7 +3,7 @@
 namespace g3 
 {
 	// ported from WildMagic5 
-	public class IntrLine2Triangle2
+	[Serializable] public class IntrLine2Triangle2
 	{
 		Line2d line;
 		public Line2d Line

--- a/intersection/IntrLine3AxisAlignedBox3.cs
+++ b/intersection/IntrLine3AxisAlignedBox3.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 	// adapted from IntrLine3Box3
-	public class IntrLine3AxisAlignedBox3
+	[Serializable] public class IntrLine3AxisAlignedBox3
 	{
 		Line3d line;
 		public Line3d Line

--- a/intersection/IntrLine3Box3.cs
+++ b/intersection/IntrLine3Box3.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 	// ported from WildMagic5 
-	public class IntrLine3Box3
+	[Serializable] public class IntrLine3Box3
 	{
 		Line3d line;
 		public Line3d Line

--- a/intersection/IntrRay3AxisAlignedBox3.cs
+++ b/intersection/IntrRay3AxisAlignedBox3.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 	// adapted from IntrRay3Box3
-	public class IntrRay3AxisAlignedBox3
+	[Serializable] public class IntrRay3AxisAlignedBox3
 	{
 		Ray3d ray;
 		public Ray3d Ray

--- a/intersection/IntrRay3Box3.cs
+++ b/intersection/IntrRay3Box3.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 	// ported from WildMagic5 
-	public class IntrRay3Box3
+	[Serializable] public class IntrRay3Box3
 	{
 		Ray3d ray;
 		public Ray3d Ray

--- a/intersection/IntrRay3Triangle3.cs
+++ b/intersection/IntrRay3Triangle3.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class IntrRay3Triangle3
+   [Serializable] public class IntrRay3Triangle3
     {
         Ray3d ray;
         public Ray3d Ray

--- a/intersection/IntrSegment2Segment2.cs
+++ b/intersection/IntrSegment2Segment2.cs
@@ -34,7 +34,7 @@ namespace g3
 	//			Type is Segment. Points are Point0 and Point1
 
 
-	public class IntrSegment2Segment2
+	[Serializable] public class IntrSegment2Segment2
     {
         Segment2d segment1;
         public Segment2d Segment1

--- a/intersection/IntrSegment2Triangle2.cs
+++ b/intersection/IntrSegment2Triangle2.cs
@@ -3,7 +3,7 @@
 namespace g3 
 {
 	// ported from WildMagic5 
-	public class IntrSegment2Triangle2
+	[Serializable] public class IntrSegment2Triangle2
 	{
 		Segment2d segment;
 		public Segment2d Segment

--- a/intersection/IntrSegment3Box3.cs
+++ b/intersection/IntrSegment3Box3.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 	// ported from WildMagic5 
-	public class IntrSegment3Box3
+	[Serializable] public class IntrSegment3Box3
 	{
 		Segment3d segment;
 		public Segment3d Segment

--- a/intersection/IntrTriangle2Triangle2.cs
+++ b/intersection/IntrTriangle2Triangle2.cs
@@ -4,7 +4,7 @@ namespace g3
 {
 	// ported from WildMagic5 
     // [TODO] Vector2d 6-tuple, to avoid internal arrays
-	public class IntrTriangle2Triangle2
+	[Serializable] public class IntrTriangle2Triangle2
 	{
 		Triangle2d triangle0;
 		public Triangle2d Triangle0

--- a/intersection/IntrTriangle3Triangle3.cs
+++ b/intersection/IntrTriangle3Triangle3.cs
@@ -8,7 +8,7 @@ namespace g3
     // use Find() to compute full information
     // By default fully-contained co-planar triangles are not reported as intersecting.
     // set ReportCoplanarIntersection=true to handle this case (more expensive)
-    public class IntrTriangle3Triangle3
+   [Serializable] public class IntrTriangle3Triangle3
     {
         Triangle3d triangle0;
         public Triangle3d Triangle0

--- a/io/BinaryG3ReaderWriter.cs
+++ b/io/BinaryG3ReaderWriter.cs
@@ -9,7 +9,7 @@ using System.Threading;
 namespace g3
 {
 
-    public class BinaryG3Writer : IMeshWriter
+   [Serializable] public class BinaryG3Writer : IMeshWriter
     {
         public IOWriteResult Write(BinaryWriter writer, List<WriteMesh> vMeshes, WriteOptions options)
         {
@@ -34,7 +34,7 @@ namespace g3
 
 
 
-    public class BinaryG3Reader : IMeshReader
+   [Serializable] public class BinaryG3Reader : IMeshReader
     {
         public IOReadResult Read(BinaryReader reader, ReadOptions options, IMeshBuilder builder)
         {

--- a/io/MaterialTypes.cs
+++ b/io/MaterialTypes.cs
@@ -19,7 +19,7 @@ namespace g3
         abstract public float Alpha { get; set; }
 
 
-        public enum KnownMaterialTypes
+       [Serializable] public enum KnownMaterialTypes
         {
             OBJ_MTL_Format
         }
@@ -30,7 +30,7 @@ namespace g3
 
     // details: http://www.fileformat.info/format/material/
     // Note: if value is initialized to Invalid vector, -1, or NaN, it was not defined in material file
-    public class OBJMaterial : GenericMaterial
+   [Serializable] public class OBJMaterial : GenericMaterial
     {
         public Vector3f Ka;     // rgb ambient reflectivity
         public Vector3f Kd;     // rgb diffuse reflectivity 

--- a/io/MeshIO.cs
+++ b/io/MeshIO.cs
@@ -7,7 +7,7 @@ using System.IO;
 namespace g3
 {
 
-    public enum IOCode
+   [Serializable] public enum IOCode
     {
         Ok = 0,
 
@@ -32,7 +32,7 @@ namespace g3
 
 
 
-    public class ReadOptions
+   [Serializable] public class ReadOptions
     {
 		public bool ReadMaterials;
 
@@ -50,7 +50,7 @@ namespace g3
         };
     }
 
-    public struct IOReadResult
+    [Serializable] public struct IOReadResult
     {
         public IOCode code { get; set; }
         public string message { get; set; }
@@ -75,7 +75,7 @@ namespace g3
 
 
 
-    public struct IOWriteResult
+    [Serializable] public struct IOWriteResult
     {
         public IOCode code { get; set; }
         public string message { get; set; }
@@ -90,7 +90,7 @@ namespace g3
 		public static readonly IOWriteResult Ok = new IOWriteResult(IOCode.Ok, "");
     }
 
-    public struct WriteOptions
+    [Serializable] public struct WriteOptions
     {
 		public bool bWriteBinary;        	// write binary format if supported (STL)
 
@@ -132,7 +132,7 @@ namespace g3
     }
 
 
-    public struct WriteMesh
+    [Serializable] public struct WriteMesh
     {
         public IMesh Mesh;
         public string Name;         // supported by some formats

--- a/io/OBJReader.cs
+++ b/io/OBJReader.cs
@@ -75,7 +75,7 @@ namespace g3
 
 
 
-    public class OBJReader : IMeshReader
+   [Serializable] public class OBJReader : IMeshReader
     {
         DVector<double> vPositions;
         DVector<float> vNormals;

--- a/io/OBJWriter.cs
+++ b/io/OBJWriter.cs
@@ -13,7 +13,7 @@ namespace g3
 	/// [TODO] options to preserve vertex and triangle indices
 	/// 
 	/// </summary>
-    public class OBJWriter : IMeshWriter
+   [Serializable] public class OBJWriter : IMeshWriter
     {
         // stream-opener. Override to write to something other than a file.
         public Func<string, Stream> OpenStreamF = (sFilename) => {

--- a/io/OFFWriter.cs
+++ b/io/OFFWriter.cs
@@ -12,7 +12,7 @@ namespace g3
 	// Write OFF mesh format
 	// https://en.wikipedia.org/wiki/OFF_(file_format)
 	//
-    public class OFFWriter : IMeshWriter
+   [Serializable] public class OFFWriter : IMeshWriter
     {
  
 

--- a/io/STLReader.cs
+++ b/io/STLReader.cs
@@ -27,10 +27,10 @@ namespace g3
     ///    DVector<short> colors = Builder.Metadata[0][STLReader.PerTriAttribMetadataName] as DVector<short>;
     /// (for DMesh3Builder, which is the only builder that supports Metadata)
     /// </summary>
-    public class STLReader : IMeshReader
+   [Serializable] public class STLReader : IMeshReader
     {
 
-        public enum Strategy
+       [Serializable] public enum Strategy
         {
             NoProcessing = 0,           // return triangle soup
             IdenticalVertexWeld = 1,    // merge identical vertices. Logically sensible but doesn't always work on ASCII STL.

--- a/io/STLWriter.cs
+++ b/io/STLWriter.cs
@@ -9,7 +9,7 @@ using System.Threading;
 namespace g3
 {
 
-    public class STLWriter : IMeshWriter
+   [Serializable] public class STLWriter : IMeshWriter
     {
         // entire data block for stl triangle, that we can directly convert to byte[]
         [StructLayout(LayoutKind.Sequential, Pack=1)]

--- a/io/SVGWriter.cs
+++ b/io/SVGWriter.cs
@@ -7,12 +7,12 @@ using System.Globalization;
 
 namespace g3
 {
-	public class SVGWriter
+	[Serializable] public class SVGWriter
 	{
         public bool FlipY = true;
 
 
-		public struct Style {
+		[Serializable] public struct Style {
 			public string fill;
 			public string stroke;
 			public float stroke_width;

--- a/io/StandardMeshReader.cs
+++ b/io/StandardMeshReader.cs
@@ -18,7 +18,7 @@ namespace g3
     }
 
 
-    public class StandardMeshReader
+   [Serializable] public class StandardMeshReader
     {
         /// <summary>
         /// If the mesh format we are writing is text, then the OS will write in the number style
@@ -246,7 +246,7 @@ namespace g3
 
 
     // MeshFormatReader impl for OBJ
-    public class OBJFormatReader : MeshFormatReader
+   [Serializable] public class OBJFormatReader : MeshFormatReader
     {
         public List<string> SupportedExtensions { get {
                 return new List<string>() { "obj" };
@@ -283,7 +283,7 @@ namespace g3
 
 
     // MeshFormatReader impl for STL
-    public class STLFormatReader : MeshFormatReader
+   [Serializable] public class STLFormatReader : MeshFormatReader
     {
         public List<string> SupportedExtensions { get {
                 return new List<string>() { "stl" };
@@ -343,7 +343,7 @@ namespace g3
 
 
     // MeshFormatReader impl for OFF
-    public class OFFFormatReader : MeshFormatReader
+   [Serializable] public class OFFFormatReader : MeshFormatReader
     {
         public List<string> SupportedExtensions { get {
                 return new List<string>() { "off" };
@@ -374,7 +374,7 @@ namespace g3
 
 
     // MeshFormatReader impl for g3mesh
-    public class BinaryG3FormatReader : MeshFormatReader
+   [Serializable] public class BinaryG3FormatReader : MeshFormatReader
     {
         public List<string> SupportedExtensions {
             get {

--- a/io/StandardMeshWriter.cs
+++ b/io/StandardMeshWriter.cs
@@ -16,7 +16,7 @@ namespace g3
     /// Each of these is implemented in a separate Writer class, eg OBJWriter, STLWriter, etc
     /// 
     /// </summary>
-    public class StandardMeshWriter : IDisposable
+   [Serializable] public class StandardMeshWriter : IDisposable
     {
 
         /// <summary>

--- a/io/gSerialization.cs
+++ b/io/gSerialization.cs
@@ -573,7 +573,7 @@ namespace g3
     /// Then you can load this data via:
     ///    SimpleStore s = SimpleStore.Restore(path)
     /// </summary>
-    public class SimpleStore
+   [Serializable] public class SimpleStore
     {
         // only ever append to this list!
         public List<DMesh3> Meshes = new List<DMesh3>();

--- a/math/AxisAlignedBox2d.cs
+++ b/math/AxisAlignedBox2d.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public struct AxisAlignedBox2d
+    [Serializable] public struct AxisAlignedBox2d
     {
         public Vector2d Min;
         public Vector2d Max;
@@ -127,7 +127,7 @@ namespace g3
             Max.x += right; Max.y += top;
         }
 
-        public enum ScaleMode {
+       [Serializable] public enum ScaleMode {
             ScaleRight,
             ScaleLeft,
             ScaleUp,

--- a/math/AxisAlignedBox2f.cs
+++ b/math/AxisAlignedBox2f.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct AxisAlignedBox2f
+    [Serializable] public struct AxisAlignedBox2f
     {
         public Vector2f Min;
         public Vector2f Max;
@@ -141,7 +141,7 @@ namespace g3
         }
 
 
-        public enum ScaleMode {
+       [Serializable] public enum ScaleMode {
             ScaleRight,
             ScaleLeft,
             ScaleUp,

--- a/math/AxisAlignedBox2i.cs
+++ b/math/AxisAlignedBox2i.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public struct AxisAlignedBox2i : IComparable<AxisAlignedBox2i>, IEquatable<AxisAlignedBox2i>
+    [Serializable] public struct AxisAlignedBox2i : IComparable<AxisAlignedBox2i>, IEquatable<AxisAlignedBox2i>
     {
         public Vector2i Min;
         public Vector2i Max;

--- a/math/AxisAlignedBox3d.cs
+++ b/math/AxisAlignedBox3d.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace g3
 {
-    public struct AxisAlignedBox3d : IComparable<AxisAlignedBox3d>, IEquatable<AxisAlignedBox3d>
+    [Serializable] public struct AxisAlignedBox3d : IComparable<AxisAlignedBox3d>, IEquatable<AxisAlignedBox3d>
     {
         public Vector3d Min;
         public Vector3d Max;

--- a/math/AxisAlignedBox3f.cs
+++ b/math/AxisAlignedBox3f.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct AxisAlignedBox3f : IComparable<AxisAlignedBox3f>, IEquatable<AxisAlignedBox3f>
+    [Serializable] public struct AxisAlignedBox3f : IComparable<AxisAlignedBox3f>, IEquatable<AxisAlignedBox3f>
     {
         public Vector3f Min;
         public Vector3f Max;

--- a/math/AxisAlignedBox3i.cs
+++ b/math/AxisAlignedBox3i.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public struct AxisAlignedBox3i : IComparable<AxisAlignedBox3i>, IEquatable<AxisAlignedBox3i>
+    [Serializable] public struct AxisAlignedBox3i : IComparable<AxisAlignedBox3i>, IEquatable<AxisAlignedBox3i>
     {
         public Vector3i Min;
         public Vector3i Max;

--- a/math/Box2.cs
+++ b/math/Box2.cs
@@ -3,7 +3,7 @@
 namespace g3 {
 
 	// partially based on WildMagic5 Box2
-	public struct Box2d
+	[Serializable] public struct Box2d
 	{
 		// A box has center C, axis directions U[0] and U[1] (perpendicular and
 		// unit-length vectors), and extents e[0] and e[1] (nonnegative numbers).
@@ -313,7 +313,7 @@ namespace g3 {
 
 
 	// partially based on WildMagic5 Box3
-	public struct Box2f
+	[Serializable] public struct Box2f
 	{
 		// A box has center C, axis directions U[0] and U[1] (perpendicular and
 		// unit-length vectors), and extents e[0] and e[1] (nonnegative numbers).

--- a/math/Box3.cs
+++ b/math/Box3.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace g3 {
 
 	// partially based on WildMagic5 Box3
-	public struct Box3d
+	[Serializable] public struct Box3d
 	{
 		// A box has center C, axis directions U[0], U[1], and U[2] (mutually
 		// perpendicular unit-length vectors), and extents e[0], e[1], and e[2]
@@ -444,7 +444,7 @@ namespace g3 {
 
 
 	// partially based on WildMagic5 Box3
-	public struct Box3f
+	[Serializable] public struct Box3f
 	{
 		// A box has center C, axis directions U[0], U[1], and U[2] (mutually
 		// perpendicular unit-length vectors), and extents e[0], e[1], and e[2]

--- a/math/Frame3f.cs
+++ b/math/Frame3f.cs
@@ -6,7 +6,7 @@ using g3;
 
 namespace g3
 {
-    public struct Frame3f
+    [Serializable] public struct Frame3f
     {
         Quaternionf rotation;
         Vector3f origin;

--- a/math/IndexTypes.cs
+++ b/math/IndexTypes.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
 
-    public struct Index3i : IComparable<Index3i>, IEquatable<Index3i>
+    [Serializable] public struct Index3i : IComparable<Index3i>, IEquatable<Index3i>
     {
         public int a;
         public int b;
@@ -163,7 +163,7 @@ namespace g3
 
 
 
-    public struct Index2i : IComparable<Index2i>, IEquatable<Index2i>
+    [Serializable] public struct Index2i : IComparable<Index2i>, IEquatable<Index2i>
     {
         public int a;
         public int b;
@@ -309,7 +309,7 @@ namespace g3
 
 
 
-    public struct Index4i
+    [Serializable] public struct Index4i
     {
         public int a;
         public int b;

--- a/math/IndexUtil.cs
+++ b/math/IndexUtil.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public class IndexUtil
+   [Serializable] public class IndexUtil
     {
         // test if [a0,a1] and [b0,b1] are the same pair, ignoring order
         public static bool same_pair_unordered(int a0, int a1, int b0, int b1)

--- a/math/Interval1d.cs
+++ b/math/Interval1d.cs
@@ -4,7 +4,7 @@ namespace g3
 {
 	// interval [a,b] on Real line. 
 	//   TODO: should check that a <= b !!
-    public struct Interval1d
+    [Serializable] public struct Interval1d
     {
 		public double a;
 		public double b;

--- a/math/Interval1i.cs
+++ b/math/Interval1i.cs
@@ -9,7 +9,7 @@ namespace g3
     //  enumerate over the range of values (inclusive!!)
     //
 	//   TODO: should check that a <= b !!
-    public struct Interval1i : IEnumerable<int>
+    [Serializable] public struct Interval1i : IEnumerable<int>
     {
 		public int a;
 		public int b;

--- a/math/Line2.cs
+++ b/math/Line2.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Line2d
+    [Serializable] public struct Line2d
     {
         public Vector2d Origin;
         public Vector2d Direction;
@@ -111,7 +111,7 @@ namespace g3
     }
 
 
-    public struct Line2f
+    [Serializable] public struct Line2f
     {
         public Vector2f Origin;
         public Vector2f Direction;

--- a/math/Line3.cs
+++ b/math/Line3.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Line3d
+    [Serializable] public struct Line3d
     {
         public Vector3d Origin;
         public Vector3d Direction;
@@ -53,7 +53,7 @@ namespace g3
     }
 
 
-    public struct Line3f
+    [Serializable] public struct Line3f
     {
         public Vector3f Origin;
         public Vector3f Direction;

--- a/math/Matrix2d.cs
+++ b/math/Matrix2d.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // some functions ported from WildMagic5 Matrix2
-    public class Matrix2d
+   [Serializable] public class Matrix2d
     {
         public double m00, m01, m10, m11;
 

--- a/math/Matrix2f.cs
+++ b/math/Matrix2f.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // some functions ported from WildMagic5 Matrix2
-    public class Matrix2f
+   [Serializable] public class Matrix2f
     {
         public float m00, m01, m10, m11;
 

--- a/math/Matrix3d.cs
+++ b/math/Matrix3d.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Matrix3d
+    [Serializable] public struct Matrix3d
     {
         public Vector3d Row0;
         public Vector3d Row1;

--- a/math/Matrix3f.cs
+++ b/math/Matrix3f.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Matrix3f
+    [Serializable] public struct Matrix3f
     {
         public Vector3f Row0;
         public Vector3f Row1;

--- a/math/Plane3.cs
+++ b/math/Plane3.cs
@@ -4,7 +4,7 @@ namespace g3
 {
     //3D plane, based on WildMagic5 Wm5Plane3 class
 
-    public struct Plane3d
+    [Serializable] public struct Plane3d
     {
         public Vector3d Normal;
         public double Constant;
@@ -63,7 +63,7 @@ namespace g3
 
 
 
-    public struct Plane3f
+    [Serializable] public struct Plane3f
     {
         public Vector3f Normal;
         public float Constant;

--- a/math/PrimalQuery2d.cs
+++ b/math/PrimalQuery2d.cs
@@ -245,7 +245,7 @@ namespace g3
         //   ORDER_COLLINEAR_LEFT when the line ordering is <P,Q0,Q1>
         //   ORDER_COLLINEAR_RIGHT when the line ordering is <Q0,Q1,P>
         //   ORDER_COLLINEAR_CONTAIN when the line ordering is <Q0,P,Q1>
-        public enum OrderType
+       [Serializable] public enum OrderType
         {
             ORDER_Q0_EQUALS_Q1,
             ORDER_P_EQUALS_Q0,

--- a/math/Quaterniond.cs
+++ b/math/Quaterniond.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace g3
 {
     // mostly ported from WildMagic5 Wm5Quaternion, from geometrictools.com
-    public struct Quaterniond
+    [Serializable] public struct Quaterniond
     {
         // note: in Wm5 version, this is a 4-element array stored in order (w,x,y,z).
         public double x, y, z, w;

--- a/math/Quaternionf.cs
+++ b/math/Quaternionf.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace g3
 {
     // mostly ported from WildMagic5 Wm5Quaternion, from geometrictools.com
-    public struct Quaternionf : IComparable<Quaternionf>, IEquatable<Quaternionf>
+    [Serializable] public struct Quaternionf : IComparable<Quaternionf>, IEquatable<Quaternionf>
     {
         // note: in Wm5 version, this is a 4-element array stored in order (w,x,y,z).
         public float x, y, z, w;

--- a/math/Query2.cs
+++ b/math/Query2.cs
@@ -6,7 +6,7 @@ namespace g3
     // Port of Wm5 Query/Query2 from WildMagic5 library by David Eberly / geometrictools.com
 
 
-    public enum QueryNumberType
+   [Serializable] public enum QueryNumberType
     {
         QT_DOUBLE = 0,
         QT_INT64 = 1,
@@ -34,7 +34,7 @@ namespace g3
 
 
 
-    public class Query2d : QueryBase, Query2
+   [Serializable] public class Query2d : QueryBase, Query2
     {
         protected IList<Vector2d> mVertices;
 
@@ -209,7 +209,7 @@ namespace g3
     /// <summary>
     /// Port of WildMagic5 Query class
     /// </summary>
-    public class QueryBase
+   [Serializable] public class QueryBase
     {
 
         // Support for ordering a set of unique indices into the vertex pool.  On

--- a/math/Query2Integer.cs
+++ b/math/Query2Integer.cs
@@ -12,7 +12,7 @@ namespace g3
     /// Note that input Vector2d values are directly cast to int64 - you must
     /// scale them to suitable coordinates yourself!
     /// </summary>
-    public class Query2Int64 : Query2d
+   [Serializable] public class Query2Int64 : Query2d
     {
 
         public Query2Int64(IList<Vector2d> Vertices) : base(Vertices)

--- a/math/QueryTuple2d.cs
+++ b/math/QueryTuple2d.cs
@@ -4,7 +4,7 @@ namespace g3
 {
     // variant of Wm5::Query2, for special case of 3 points. This is used in
     // IntrTriangle3Triangle3, to avoid allocating arrays
-    public class QueryTuple2d
+   [Serializable] public class QueryTuple2d
     {
         Vector2dTuple3 mVertices;
 

--- a/math/Ray3.cs
+++ b/math/Ray3.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Ray3d
+    [Serializable] public struct Ray3d
     {
         public Vector3d Origin;
         public Vector3d Direction;
@@ -88,7 +88,7 @@ namespace g3
 
 
 
-    public struct Ray3f
+    [Serializable] public struct Ray3f
     {
         public Vector3f Origin;
         public Vector3f Direction;

--- a/math/ScalarMap.cs
+++ b/math/ScalarMap.cs
@@ -7,7 +7,7 @@ namespace g3
     /// Scalar version of a ColorMap (ie interpolate between sample points)
     /// [TODO] could we make this a template?
     /// </summary>
-    public class ScalarMap
+   [Serializable] public class ScalarMap
     {
         struct Sample
         {

--- a/math/Segment2.cs
+++ b/math/Segment2.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-	public struct Segment2d : IParametricCurve2d
+	[Serializable] public struct Segment2d : IParametricCurve2d
     {
         // Center-direction-extent representation.
         public Vector2d Center;
@@ -257,7 +257,7 @@ namespace g3
 
 
 
-    public struct Segment2f
+    [Serializable] public struct Segment2f
     {
         // Center-direction-extent representation.
         public Vector2f Center;
@@ -369,7 +369,7 @@ namespace g3
 
 
 
-	public class Segment2dBox 
+	[Serializable] public class Segment2dBox 
 	{
 		public Segment2d Segment;
 

--- a/math/Segment3.cs
+++ b/math/Segment3.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-	public struct Segment3d : IParametricCurve3d
+	[Serializable] public struct Segment3d : IParametricCurve3d
     {
         // Center-direction-extent representation.
         // Extent is half length of segment
@@ -145,7 +145,7 @@ namespace g3
 
 
 
-    public struct Segment3f
+    [Serializable] public struct Segment3f
     {
         // Center-direction-extent representation.
         // Extent is half length of segment

--- a/math/TransformSequence.cs
+++ b/math/TransformSequence.cs
@@ -14,7 +14,7 @@ namespace g3
     /// Use the Append() functions to add different transform types, and the TransformX()
     /// to apply the sequence
     /// </summary>
-    public class TransformSequence
+   [Serializable] public class TransformSequence
     {
         enum XFormType
         {

--- a/math/TransformSequence2.cs
+++ b/math/TransformSequence2.cs
@@ -23,7 +23,7 @@ namespace g3
     /// Use the Append() functions to add different transform types, and the TransformX()
     /// to apply the sequence
     /// </summary>
-    public class TransformSequence2 : ITransform2
+   [Serializable] public class TransformSequence2 : ITransform2
     {
         enum XFormType
         {

--- a/math/Triangle2.cs
+++ b/math/Triangle2.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Triangle2d
+    [Serializable] public struct Triangle2d
     {
         public Vector2d V0, V1, V2;
 
@@ -42,7 +42,7 @@ namespace g3
 
 
 
-    public struct Triangle2f
+    [Serializable] public struct Triangle2f
     {
         public Vector2f V0, V1, V2;
 

--- a/math/Triangle3.cs
+++ b/math/Triangle3.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Triangle3d
+    [Serializable] public struct Triangle3d
     {
         public Vector3d V0, V1, V2;
 
@@ -57,7 +57,7 @@ namespace g3
 
 
 
-    public struct Triangle3f
+    [Serializable] public struct Triangle3f
     {
         public Vector3f V0, V1, V2;
 

--- a/math/Vector2d.cs
+++ b/math/Vector2d.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public struct Vector2d : IComparable<Vector2d>, IEquatable<Vector2d>
+    [Serializable] public struct Vector2d : IComparable<Vector2d>, IEquatable<Vector2d>
     {
         public double x;
         public double y;
@@ -301,7 +301,7 @@ namespace g3
 
         // from WildMagic5 Vector2, used in ConvexHull2
 
-        public struct Information
+        [Serializable] public struct Information
         {
             // The intrinsic dimension of the input set.  The parameter 'epsilon'
             // to the GetInformation function is used to provide a tolerance when

--- a/math/Vector2f.cs
+++ b/math/Vector2f.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Vector2f : IComparable<Vector2f>, IEquatable<Vector2f>
+    [Serializable] public struct Vector2f : IComparable<Vector2f>, IEquatable<Vector2f>
     {
         public float x;
         public float y;

--- a/math/Vector2i.cs
+++ b/math/Vector2i.cs
@@ -2,7 +2,7 @@
 
 namespace g3
 {
-    public struct Vector2i : IComparable<Vector2i>, IEquatable<Vector2i>
+    [Serializable] public struct Vector2i : IComparable<Vector2i>, IEquatable<Vector2i>
     {
         public int x;
         public int y;
@@ -140,7 +140,7 @@ namespace g3
 
 
 
-    public struct Vector2l : IComparable<Vector2l>, IEquatable<Vector2l>
+    [Serializable] public struct Vector2l : IComparable<Vector2l>, IEquatable<Vector2l>
     {
         public long x;
         public long y;

--- a/math/Vector3d.cs
+++ b/math/Vector3d.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Vector3d : IComparable<Vector3d>, IEquatable<Vector3d>
+    [Serializable] public struct Vector3d : IComparable<Vector3d>, IEquatable<Vector3d>
     {
         public double x;
         public double y;

--- a/math/Vector3f.cs
+++ b/math/Vector3f.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Vector3f : IComparable<Vector3f>, IEquatable<Vector3f>
+    [Serializable] public struct Vector3f : IComparable<Vector3f>, IEquatable<Vector3f>
     {
         public float x;
         public float y;

--- a/math/Vector3i.cs
+++ b/math/Vector3i.cs
@@ -10,7 +10,7 @@ namespace g3
     /// Unfortunately I can't see a way to do this w/o so much duplication...we could
     /// have .x/.y/.z accessors but that is much less efficient...
     /// </summary>
-    public struct Vector3i : IComparable<Vector3i>, IEquatable<Vector3i>
+    [Serializable] public struct Vector3i : IComparable<Vector3i>, IEquatable<Vector3i>
     {
         public int x;
         public int y;

--- a/math/Vector4d.cs
+++ b/math/Vector4d.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Vector4d : IComparable<Vector4d>, IEquatable<Vector4d>
+    [Serializable] public struct Vector4d : IComparable<Vector4d>, IEquatable<Vector4d>
     {
         public double x;
         public double y;

--- a/math/Vector4f.cs
+++ b/math/Vector4f.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace g3
 {
-    public struct Vector4f : IComparable<Vector4f>, IEquatable<Vector4f>
+    [Serializable] public struct Vector4f : IComparable<Vector4f>, IEquatable<Vector4f>
     {
         public float x;
         public float y;

--- a/math/VectorTuple.cs
+++ b/math/VectorTuple.cs
@@ -6,7 +6,7 @@ namespace g3
     // (which C# does not support, but is common in C++ code)
 
 
-    public struct Vector3dTuple2
+    [Serializable] public struct Vector3dTuple2
     {
         public Vector3d V0, V1;
 
@@ -22,7 +22,7 @@ namespace g3
     }
 
 
-    public struct Vector3dTuple3
+    [Serializable] public struct Vector3dTuple3
     {
         public Vector3d V0, V1, V2;
 
@@ -40,7 +40,7 @@ namespace g3
 
 
 
-    public struct Vector3fTuple3
+    [Serializable] public struct Vector3fTuple3
     {
         public Vector3f V0, V1, V2;
 
@@ -59,7 +59,7 @@ namespace g3
 
 
 
-    public struct Vector2dTuple2
+    [Serializable] public struct Vector2dTuple2
     {
         public Vector2d V0, V1;
 
@@ -76,7 +76,7 @@ namespace g3
     }
 
 
-    public struct Vector2dTuple3
+    [Serializable] public struct Vector2dTuple3
     {
         public Vector2d V0, V1, V2;
 
@@ -93,7 +93,7 @@ namespace g3
     }
 
 
-    public struct Vector2dTuple4
+    [Serializable] public struct Vector2dTuple4
     {
         public Vector2d V0, V1, V2, V3;
 

--- a/mesh/DMesh3.cs
+++ b/mesh/DMesh3.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace g3
 {
-    public enum MeshResult
+   [Serializable] public enum MeshResult
     {
         Ok = 0,
         Failed_NotAVertex = 1,
@@ -39,7 +39,7 @@ namespace g3
 
 
     [Flags]
-    public enum MeshComponents
+   [Serializable] public enum MeshComponents
     {
         None = 0,
         VertexNormals = 1,
@@ -50,7 +50,7 @@ namespace g3
     }
 
     [Flags]
-    public enum MeshHints
+   [Serializable] public enum MeshHints
     {
         None = 0,
         IsCompact = 1
@@ -198,7 +198,7 @@ namespace g3
         }
 
 
-        public struct CompactInfo
+        [Serializable] public struct CompactInfo
         {
             public IIndexMap MapV;
         }

--- a/mesh/DMesh3Builder.cs
+++ b/mesh/DMesh3Builder.cs
@@ -5,9 +5,9 @@ using System.Linq;
 
 namespace g3
 {
-    public class DMesh3Builder : IMeshBuilder
+   [Serializable] public class DMesh3Builder : IMeshBuilder
     {
-        public enum AddTriangleFailBehaviors
+       [Serializable] public enum AddTriangleFailBehaviors
         {
             DiscardTriangle = 0,
             DuplicateAllVertices = 1

--- a/mesh/DMesh3Changes.cs
+++ b/mesh/DMesh3Changes.cs
@@ -9,7 +9,7 @@ namespace g3
     /// Mesh change for vertex deformations. Currently minimal support for initializing buffers.
     /// AppendNewVertex() can be used to accumulate modified vertices and their initial positions.
     /// </summary>
-    public class ModifyVerticesMeshChange
+   [Serializable] public class ModifyVerticesMeshChange
     {
         public DVector<int> ModifiedV;
         public DVector<Vector3d> OldPositions, NewPositions;
@@ -115,7 +115,7 @@ namespace g3
     /// Mesh change for full-mesh vertex deformations - more efficient than ModifyVerticesMeshChange.
     /// Note that this does not enforce that vertex count does not change!
     /// </summary>
-    public class SetVerticesMeshChange
+   [Serializable] public class SetVerticesMeshChange
     {
         public DVector<double> OldPositions, NewPositions;
         public DVector<float> OldNormals, NewNormals;
@@ -175,7 +175,7 @@ namespace g3
     /// Vertex and Triangle IDs will be restored on Revert()
     /// Currently does *not* restore the same EdgeIDs
     /// </summary>
-    public class RemoveTrianglesMeshChange
+   [Serializable] public class RemoveTrianglesMeshChange
     {
         protected DVector<int> RemovedV;
         protected DVector<Vector3d> Positions;
@@ -360,7 +360,7 @@ namespace g3
     /// Vertex and Triangle IDs will be restored on Revert()
     /// Currently does *not* restore the same EdgeIDs
     /// </summary>
-    public class AddTrianglesMeshChange
+   [Serializable] public class AddTrianglesMeshChange
     {
         protected DVector<int> AddedV;
         protected DVector<Vector3d> Positions;

--- a/mesh/DMesh3_edge_operators.cs
+++ b/mesh/DMesh3_edge_operators.cs
@@ -256,7 +256,7 @@ namespace g3
 
 
 
-        public struct EdgeSplitInfo {
+        [Serializable] public struct EdgeSplitInfo {
 			public bool bIsBoundary;
 			public int vNew;
 			public int eNewBN;      // new edge [vNew,vB] (original was AB)
@@ -440,7 +440,7 @@ namespace g3
 
 
 
-		public struct EdgeFlipInfo {
+		[Serializable] public struct EdgeFlipInfo {
 			public int eID;
 			public int v0,v1;
 			public int ov0,ov1;
@@ -552,7 +552,7 @@ namespace g3
 		}
 
 
-		public struct EdgeCollapseInfo {
+		[Serializable] public struct EdgeCollapseInfo {
 			public int vKept;
 			public int vRemoved;
 			public bool bIsBoundary;
@@ -791,7 +791,7 @@ namespace g3
 
 
 
-		public struct MergeEdgesInfo
+		[Serializable] public struct MergeEdgesInfo
 		{
 			public int eKept;
 			public int eRemoved;
@@ -1003,7 +1003,7 @@ namespace g3
 
 
 
-        public struct PokeTriangleInfo
+        [Serializable] public struct PokeTriangleInfo
         {
             public int new_vid;
             public int new_t1, new_t2;

--- a/mesh/DSubmesh3.cs
+++ b/mesh/DSubmesh3.cs
@@ -9,7 +9,7 @@ namespace g3
 
 
 
-    public class DSubmesh3
+   [Serializable] public class DSubmesh3
     {
         public DMesh3 BaseMesh;
         public DMesh3 SubMesh;

--- a/mesh/DSubmesh3Set.cs
+++ b/mesh/DSubmesh3Set.cs
@@ -14,7 +14,7 @@ namespace g3
     /// that returns the triangle index list for a given key. The set of DSubmesh3
     /// objects are computed on construction.
     /// </summary>
-    public class DSubmesh3Set : IEnumerable<DSubmesh3>
+   [Serializable] public class DSubmesh3Set : IEnumerable<DSubmesh3>
     {
         public DMesh3 Mesh;
 

--- a/mesh/EdgeLoop.cs
+++ b/mesh/EdgeLoop.cs
@@ -10,7 +10,7 @@ namespace g3
     /// 
     /// If all you have are the vertices, use EdgeLoop.VertexLoopToEdgeLoop() to construct an EdgeLoop
     /// </summary>
-    public class EdgeLoop
+   [Serializable] public class EdgeLoop
     {
         public DMesh3 Mesh;
 

--- a/mesh/EdgeLoopRemesher.cs
+++ b/mesh/EdgeLoopRemesher.cs
@@ -15,7 +15,7 @@ namespace g3
     /// [TODO] local-smoothing impl is not very efficient. Should not be necessary to
     ///    rebuild nbrhood each time if we are not changing it.
     /// </summary>
-    public class EdgeLoopRemesher : Remesher
+   [Serializable] public class EdgeLoopRemesher : Remesher
     {
         public EdgeLoop InputLoop;
         public EdgeLoop OutputLoop;

--- a/mesh/EdgeSpan.cs
+++ b/mesh/EdgeSpan.cs
@@ -8,7 +8,7 @@ namespace g3
 	/// An EdgeSpan is a continous set of edges in a Mesh that is *not* closed
 	/// (that would be an EdgeLoop)
 	/// </summary>
-    public class EdgeSpan
+   [Serializable] public class EdgeSpan
     {
         public DMesh3 Mesh;
 

--- a/mesh/FaceGroupOptimizer.cs
+++ b/mesh/FaceGroupOptimizer.cs
@@ -10,7 +10,7 @@ namespace g3
     /// This involves flipping triangles between groups, and/or assigning to "background" group.
     /// Also has Dilate/Contract functions to grow/shrink groups in various ways.
     /// </summary>
-    public class FaceGroupOptimizer
+   [Serializable] public class FaceGroupOptimizer
     {
         // cannot change this w/o updating GetEnumeratorF
         DMesh3 mesh;

--- a/mesh/IMesh.cs
+++ b/mesh/IMesh.cs
@@ -61,7 +61,7 @@ namespace g3
     /*
      * Abstracts construction of meshes, so that we can construct different types, etc
      */
-    public struct NewVertexInfo
+    [Serializable] public struct NewVertexInfo
     {
         public Vector3d v;
         public Vector3f n, c;

--- a/mesh/MeshCaches.cs
+++ b/mesh/MeshCaches.cs
@@ -9,7 +9,7 @@ namespace g3
     /*
      * Basic cache of per-triangle information for a DMesh3
      */
-    public class MeshTriInfoCache
+   [Serializable] public class MeshTriInfoCache
     {
         public DVector<Vector3d> Centroids;
         public DVector<Vector3d> Normals;

--- a/mesh/MeshConstraints.cs
+++ b/mesh/MeshConstraints.cs
@@ -6,7 +6,7 @@ namespace g3
 {
 
     [Flags]
-    public enum EdgeRefineFlags
+   [Serializable] public enum EdgeRefineFlags
     {
         NoConstraint = 0,
         NoFlip = 1,
@@ -20,7 +20,7 @@ namespace g3
     }
 
 
-    public struct EdgeConstraint
+    [Serializable] public struct EdgeConstraint
     {
         EdgeRefineFlags refineFlags;
         public IProjectionTarget Target;        // edge is associated with this projection Target.
@@ -69,7 +69,7 @@ namespace g3
 
 
 
-    public struct VertexConstraint
+    [Serializable] public struct VertexConstraint
     {
         public bool Fixed;
         public int FixedSetID;      // in Remesher, we can allow two Fixed vertices with 
@@ -104,7 +104,7 @@ namespace g3
 
 
 
-    public class MeshConstraints
+   [Serializable] public class MeshConstraints
     {
 
         Dictionary<int, EdgeConstraint> Edges = new Dictionary<int, EdgeConstraint>();

--- a/mesh/MeshDecomposition.cs
+++ b/mesh/MeshDecomposition.cs
@@ -19,7 +19,7 @@ namespace g3
     // [TODO] 
     //    - build strategy using AABB tree traversal
     //    - option to store components here (currently if client does not hold, we are discarding)
-    public class MeshDecomposition
+   [Serializable] public class MeshDecomposition
     {
         DMesh3 mesh;
 
@@ -32,7 +32,7 @@ namespace g3
         public IMeshComponentManager Manager { set; get; }
 
 
-        public struct Component
+        [Serializable] public struct Component
         {
             public int id;              // probably linear index
 

--- a/mesh/MeshEditor.cs
+++ b/mesh/MeshEditor.cs
@@ -13,7 +13,7 @@ namespace g3
     //   - (?)
     //
     // 
-    public class MeshEditor
+   [Serializable] public class MeshEditor
     {
         public DMesh3 Mesh;
 
@@ -667,7 +667,7 @@ namespace g3
         // This enum/argument controls the behavior. 
         // However, fundamentally this kind of problem should be handled upstream!! For example by not trying
         // to remesh areas that contain nonmanifold geometry...
-        public enum DuplicateTriBehavior
+       [Serializable] public enum DuplicateTriBehavior
         {
             AssertContinue,         // check will not be done in Release!
             AssertAbort, UseExisting, Replace

--- a/mesh/MeshMeasurements.cs
+++ b/mesh/MeshMeasurements.cs
@@ -416,7 +416,7 @@ namespace g3
 
 
 
-        public struct GenusResult
+        [Serializable] public struct GenusResult
         {
             public bool Valid;
             public int Genus;

--- a/mesh/MeshNormals.cs
+++ b/mesh/MeshNormals.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace g3
 {
-    public class MeshNormals
+   [Serializable] public class MeshNormals
     {
         public IMesh Mesh;
         public DVector<Vector3d> Normals;
@@ -18,7 +18,7 @@ namespace g3
 
 
 
-        public enum NormalsTypes
+       [Serializable] public enum NormalsTypes
         {
             Vertex_OneRingFaceAverage_AreaWeighted
         }

--- a/mesh/MeshPointSets.cs
+++ b/mesh/MeshPointSets.cs
@@ -9,7 +9,7 @@ namespace g3
     /// <summary>
     /// Present mesh edge midpoints as a point set
     /// </summary>
-    public class MeshEdgeMidpoints : IPointSet
+   [Serializable] public class MeshEdgeMidpoints : IPointSet
     {
         public MeshEdgeMidpoints(DMesh3 mesh)
         {
@@ -50,7 +50,7 @@ namespace g3
     /// <summary>
     /// Present mesh boundary-edge midpoints as a point set
     /// </summary>
-    public class MeshBoundaryEdgeMidpoints : IPointSet
+   [Serializable] public class MeshBoundaryEdgeMidpoints : IPointSet
     {
         public MeshBoundaryEdgeMidpoints(DMesh3 mesh)
         {

--- a/mesh/MeshRefinerBase.cs
+++ b/mesh/MeshRefinerBase.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class MeshRefinerBase
+   [Serializable] public class MeshRefinerBase
     {
         protected DMesh3 mesh;
         protected MeshConstraints constraints = null;

--- a/mesh/MeshUVSet.cs
+++ b/mesh/MeshUVSet.cs
@@ -7,7 +7,7 @@ namespace g3
 	// Standalone UV mesh
 	//   (mainly we are using this as a UV layer for an existing 3D Mesh, so the assumption
 	//    is that TriangleUVs has the same # of triangles as that mesh...)
-    public class DenseUVMesh
+   [Serializable] public class DenseUVMesh
     {
         public DVector<Vector2f> UVs;
         public DVector<Index3i> TriangleUVs;

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -1258,7 +1258,7 @@ namespace g3
 
 
 
-        public struct EdgeSplitInfo
+        [Serializable] public struct EdgeSplitInfo
         {
             public bool bIsBoundary;
             public int vNew;
@@ -1385,7 +1385,7 @@ namespace g3
 
 
 
-        public struct PokeTriangleInfo
+        [Serializable] public struct PokeTriangleInfo
         {
             public int new_vid;
             public int new_t1, new_t2;

--- a/mesh/Reducer.cs
+++ b/mesh/Reducer.cs
@@ -10,7 +10,7 @@ namespace g3
     /// Mesh Simplication - implementation of Garland & Heckbert Quadric Error Metric (QEM) Simplification
     /// 
     /// </summary>
-	public class Reducer : MeshRefinerBase
+	[Serializable] public class Reducer : MeshRefinerBase
 	{
         protected IProjectionTarget target = null;
 
@@ -771,7 +771,7 @@ skip_to_end:
 	/// - vector b
 	/// - constant c
 	/// </summary>
-	public struct QuadricError {
+	[Serializable] public struct QuadricError {
 		public double Axx, Axy, Axz, Ayy, Ayz, Azz;
 		public double bx, by, bz;
 		public double c;

--- a/mesh/RegionRemesher.cs
+++ b/mesh/RegionRemesher.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace g3
 {
-    public class RegionRemesher : Remesher
+   [Serializable] public class RegionRemesher : Remesher
     {
         public DMesh3 BaseMesh;
         public DSubmesh3 Region;
@@ -157,7 +157,7 @@ namespace g3
 
 
         [Flags]
-        public enum QuickRemeshFlags
+       [Serializable] public enum QuickRemeshFlags
         {
             NoFlags = 0,
             PreventNormalFlips = 1

--- a/mesh/Remesher.cs
+++ b/mesh/Remesher.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace g3 {
 	
-	public class Remesher : MeshRefinerBase
+	[Serializable] public class Remesher : MeshRefinerBase
     {
         IProjectionTarget target = null;
 
@@ -33,7 +33,7 @@ namespace g3 {
         // Sometimes we need to have very granular control over what happens to
         // specific vertices. This function allows client to specify such behavior.
         // Somewhat redundant w/ VertexConstraints, but simpler to code.
-        [Flags] public enum VertexControl
+        [Flags][Serializable] public enum VertexControl
         {
             AllowAll = 0,
             NoSmooth = 1,
@@ -49,7 +49,7 @@ namespace g3 {
         public List<int> DebugEdges = new List<int>();
 
         // if Target is set, we can project onto it in different ways
-        public enum TargetProjectionMode
+       [Serializable] public enum TargetProjectionMode
         {
             NoProjection,           // disable projection
             AfterRefinement,        // do all projection after the refine/smooth pass

--- a/mesh/RemesherPro.cs
+++ b/mesh/RemesherPro.cs
@@ -20,7 +20,7 @@ namespace gs
     ///  - TrackedProjectionPass() same
     /// 
     /// </summary>
-    public class RemesherPro : Remesher
+   [Serializable] public class RemesherPro : Remesher
     {
 
         public bool UseFaceAlignedProjection = false;

--- a/mesh/SimpleMesh.cs
+++ b/mesh/SimpleMesh.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace g3
 {
-    public class SimpleMesh : IDeformableMesh
+   [Serializable] public class SimpleMesh : IDeformableMesh
     {
         public DVector<double> Vertices;
         public DVector<float> Normals;
@@ -516,7 +516,7 @@ namespace g3
 
 
 
-    public class SimpleMeshBuilder : IMeshBuilder
+   [Serializable] public class SimpleMeshBuilder : IMeshBuilder
     {
         public List<SimpleMesh> Meshes;
         public List<GenericMaterial> Materials;

--- a/mesh/SimpleQuadMesh.cs
+++ b/mesh/SimpleQuadMesh.cs
@@ -11,7 +11,7 @@ namespace g3
     /// use static WriteOBJ() to save. No loading, for now. 
     /// 
     /// </summary>
-    public class SimpleQuadMesh
+   [Serializable] public class SimpleQuadMesh
     {
         public DVector<double> Vertices;
         public DVector<float> Normals;

--- a/mesh_generators/ArrowGenerators.cs
+++ b/mesh_generators/ArrowGenerators.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
     // radially-symmetric 3D arrow
-    public class Radial3DArrowGenerator : VerticalGeneralizedCylinderGenerator
+   [Serializable] public class Radial3DArrowGenerator : VerticalGeneralizedCylinderGenerator
     {
         public float StickRadius = 0.5f;
         public float StickLength = 1.0f;

--- a/mesh_generators/BoxGenerators.cs
+++ b/mesh_generators/BoxGenerators.cs
@@ -7,7 +7,7 @@ namespace g3
     /// <summary>
     /// Generate a minimal box
     /// </summary>
-    public class TrivialBox3Generator : MeshGenerator
+   [Serializable] public class TrivialBox3Generator : MeshGenerator
     {
         public Box3d Box = Box3d.UnitZeroCentered;
         public bool NoSharedVertices = false;
@@ -68,7 +68,7 @@ namespace g3
     /// with EdgeVertices verts along each edge.
     /// [TODO] allow varying EdgeVertices in each dimension (tricky...)
     /// </summary>
-    public class GridBox3Generator : MeshGenerator
+   [Serializable] public class GridBox3Generator : MeshGenerator
     {
         public Box3d Box = Box3d.UnitZeroCentered;
         public int EdgeVertices = 8;

--- a/mesh_generators/CylinderGenerators.cs
+++ b/mesh_generators/CylinderGenerators.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
     // generate a cylinder 
-    public class OpenCylinderGenerator : MeshGenerator
+   [Serializable] public class OpenCylinderGenerator : MeshGenerator
     {
         public float BaseRadius = 1.0f;
         public float TopRadius = 1.0f;
@@ -69,7 +69,7 @@ namespace g3
     /// No subdivisions along top/base rings or height steps.
     /// cylinder triangles have groupid = 1, top cap = 2, bottom cap = 3, wedge faces 5 and 6
     /// </summary>
-    public class CappedCylinderGenerator : MeshGenerator
+   [Serializable] public class CappedCylinderGenerator : MeshGenerator
     {
         public float BaseRadius = 1.0f;
         public float TopRadius = 1.0f;
@@ -206,7 +206,7 @@ namespace g3
     // This causes the normals to look...weird.
     // For the conical region, we use the planar disc parameterization (ie tip at .5,.5) rather than
     // a cylinder-like projection
-    public class ConeGenerator : MeshGenerator
+   [Serializable] public class ConeGenerator : MeshGenerator
     {
         public float BaseRadius = 1.0f;
         public float Height = 1.0f;
@@ -321,7 +321,7 @@ namespace g3
 
 
 
-    public class VerticalGeneralizedCylinderGenerator : MeshGenerator
+   [Serializable] public class VerticalGeneralizedCylinderGenerator : MeshGenerator
     {
         public CircularSection[] Sections;
         public int Slices = 16;

--- a/mesh_generators/DiscGenerators.cs
+++ b/mesh_generators/DiscGenerators.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
     // generate a triangle fan, no subdvisions
-    public class TrivialDiscGenerator : MeshGenerator
+   [Serializable] public class TrivialDiscGenerator : MeshGenerator
     {
         public float Radius = 1.0f;
         public float StartAngleDeg = 0.0f;
@@ -56,7 +56,7 @@ namespace g3
 
 
     // generate a triangle fan, no subdvisions
-    public class PuncturedDiscGenerator : MeshGenerator
+   [Serializable] public class PuncturedDiscGenerator : MeshGenerator
     {
         public float OuterRadius = 1.0f;
         public float InnerRadius = 0.5f;

--- a/mesh_generators/GenCylGenerators.cs
+++ b/mesh_generators/GenCylGenerators.cs
@@ -20,7 +20,7 @@ namespace g3
     /// vertex normals
     /// 
     /// </summary>
-    public class TubeGenerator : MeshGenerator
+   [Serializable] public class TubeGenerator : MeshGenerator
     {
         public List<Vector3d> Vertices;
         public Polygon2d Polygon;

--- a/mesh_generators/MarchingCubes.cs
+++ b/mesh_generators/MarchingCubes.cs
@@ -17,7 +17,7 @@ namespace g3
     /// [TODO] hash table for edge vtx-indices instead, like old polygonizer? (how did we index edges?!?)
     /// 
     /// </summary>
-    public class MarchingCubes
+   [Serializable] public class MarchingCubes
     {
         /// <summary>
         /// this is the function we will evaluate
@@ -49,7 +49,7 @@ namespace g3
         public bool ParallelCompute = true;
 
 
-        public enum RootfindingModes { SingleLerp, LerpSteps, Bisection }
+       [Serializable] public enum RootfindingModes { SingleLerp, LerpSteps, Bisection }
 
         /// <summary>
         /// Which rootfinding method will be used to converge on surface along edges

--- a/mesh_generators/MarchingCubesPro.cs
+++ b/mesh_generators/MarchingCubesPro.cs
@@ -9,7 +9,7 @@ using g3;
 
 namespace gs
 {
-    public class MarchingCubesPro
+   [Serializable] public class MarchingCubesPro
     {
         /// <summary>
         /// this is the function we will evaluate
@@ -40,7 +40,7 @@ namespace gs
         /// </summary>
         public bool ParallelCompute = true;
 
-        public enum RootfindingModes { SingleLerp, LerpSteps, Bisection }
+       [Serializable] public enum RootfindingModes { SingleLerp, LerpSteps, Bisection }
 
         /// <summary>
         /// Which rootfinding method will be used to converge on surface along edges

--- a/mesh_generators/PlaneGenerators.cs
+++ b/mesh_generators/PlaneGenerators.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace g3
 {
     // generate a two-triangle rect, centered at origin
-    public class TrivialRectGenerator : MeshGenerator
+   [Serializable] public class TrivialRectGenerator : MeshGenerator
     {
         public float Width = 1.0f;
         public float Height = 1.0f;
@@ -20,7 +20,7 @@ namespace g3
         /// </summary>
         public Index2i IndicesMap = new Index2i(1, 3);
 
-        public enum UVModes
+       [Serializable] public enum UVModes
         {
             FullUVSquare,
             CenteredUVRectangle,
@@ -102,7 +102,7 @@ namespace g3
     /// with EdgeVertices verts along each edge.
     /// [TODO] allow varying EdgeVertices in each dimension (tricky...)
     /// </summary>
-    public class GriddedRectGenerator : TrivialRectGenerator
+   [Serializable] public class GriddedRectGenerator : TrivialRectGenerator
     {
         public int EdgeVertices = 8;
 
@@ -197,7 +197,7 @@ namespace g3
 
     // Generate a rounded rect centered at origin.
     // Force individual corners to be sharp using the SharpCorners flags field.
-    public class RoundRectGenerator : MeshGenerator
+   [Serializable] public class RoundRectGenerator : MeshGenerator
     {
         public float Width = 1.0f;
         public float Height = 1.0f;
@@ -206,7 +206,7 @@ namespace g3
 
 
         [Flags]
-        public enum Corner
+       [Serializable] public enum Corner
         {
             BottomLeft = 1,
             BottomRight = 2,
@@ -216,7 +216,7 @@ namespace g3
         public Corner SharpCorners = 0;
 
 
-        public enum UVModes
+       [Serializable] public enum UVModes
         {
             FullUVSquare,
             CenteredUVRectangle,

--- a/mesh_generators/PointsMeshGenerators.cs
+++ b/mesh_generators/PointsMeshGenerators.cs
@@ -8,7 +8,7 @@ namespace g3
     /// Create a mesh that contains a planar element for each point and normal
     /// (currently only triangles)
     /// </summary>
-    public class PointSplatsGenerator : MeshGenerator
+   [Serializable] public class PointSplatsGenerator : MeshGenerator
     {
         public IEnumerable<int> PointIndices;
         public int PointIndicesCount = -1;      // you can set this to avoid calling Count() on enumerable

--- a/mesh_generators/RevolveGenerator.cs
+++ b/mesh_generators/RevolveGenerator.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class Curve3Axis3RevolveGenerator : MeshGenerator
+   [Serializable] public class Curve3Axis3RevolveGenerator : MeshGenerator
     {
         public Vector3d[] Curve;
 
@@ -160,7 +160,7 @@ namespace g3
 
 
 
-    public class Curve3Curve3RevolveGenerator : MeshGenerator
+   [Serializable] public class Curve3Curve3RevolveGenerator : MeshGenerator
     {
         public Vector3d[] Curve;
         public Vector3d[] Axis;

--- a/mesh_generators/SphereGenerators.cs
+++ b/mesh_generators/SphereGenerators.cs
@@ -10,11 +10,11 @@ namespace g3
     /// Generate a mesh of a sphere by first generating a mesh of a cube, 
     /// and then normalizing the vertices and moving them to sphere of desired radius.
     /// </summary>
-    public class Sphere3Generator_NormalizedCube : GridBox3Generator
+   [Serializable] public class Sphere3Generator_NormalizedCube : GridBox3Generator
     {
         public double Radius = 1.0;
 
-        public enum NormalizationTypes
+       [Serializable] public enum NormalizationTypes
         {
             NormalizedVector,
             CubeMapping             // produces more even distribution of quads

--- a/mesh_generators/TriangulatedPolygonGenerator.cs
+++ b/mesh_generators/TriangulatedPolygonGenerator.cs
@@ -6,7 +6,7 @@ namespace g3
     /// Triangulate a 2D polygon-with-holes by inserting it's edges into a meshed rectangle
     /// and then removing the triangles outside the polygon.
     /// </summary>
-    public class TriangulatedPolygonGenerator : MeshGenerator
+   [Serializable] public class TriangulatedPolygonGenerator : MeshGenerator
     {
         public GeneralPolygon2d Polygon;
         public Vector3f FixedNormal = Vector3f.AxisZ;

--- a/mesh_generators/VoxelSurfaceGenerator.cs
+++ b/mesh_generators/VoxelSurfaceGenerator.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class VoxelSurfaceGenerator
+   [Serializable] public class VoxelSurfaceGenerator
     {
         public IBinaryVoxelGrid Voxels;
 

--- a/mesh_ops/AutoHoleFill.cs
+++ b/mesh_ops/AutoHoleFill.cs
@@ -16,7 +16,7 @@ namespace gs
     /// then uses PlanarSpansFiller. See comments, is not really functional.
     /// 
     /// </summary>
-    public class AutoHoleFill
+   [Serializable] public class AutoHoleFill
     {
         public DMesh3 Mesh;
 

--- a/mesh_ops/LaplacianMeshDeformer.cs
+++ b/mesh_ops/LaplacianMeshDeformer.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class LaplacianMeshDeformer
+   [Serializable] public class LaplacianMeshDeformer
     {
         public DMesh3 Mesh;
 
@@ -17,7 +17,7 @@ namespace g3
         double[] MLx, MLy, MLz;
 
         // constraints
-        public struct SoftConstraintV
+        [Serializable] public struct SoftConstraintV
         {
             public Vector3d Position;
             public double Weight;

--- a/mesh_ops/LaplacianMeshSmoother.cs
+++ b/mesh_ops/LaplacianMeshSmoother.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class LaplacianMeshSmoother
+   [Serializable] public class LaplacianMeshSmoother
     {
         public DMesh3 Mesh;
 
@@ -17,7 +17,7 @@ namespace g3
         double[] MLx, MLy, MLz;
 
         // constraints
-        public struct SoftConstraintV
+        [Serializable] public struct SoftConstraintV
         {
             public Vector3d Position;
             public double Weight;

--- a/mesh_ops/MergeCoincidentEdges.cs
+++ b/mesh_ops/MergeCoincidentEdges.cs
@@ -9,7 +9,7 @@ namespace gs
 	/// <summary>
 	/// Merge coincident edges.
 	/// </summary>
-	public class MergeCoincidentEdges
+	[Serializable] public class MergeCoincidentEdges
 	{
 		public DMesh3 Mesh;
 

--- a/mesh_ops/MeshAssembly.cs
+++ b/mesh_ops/MeshAssembly.cs
@@ -14,7 +14,7 @@ namespace gs
     /// Given an input mesh, try to decompose it's connected components into
     /// parts with some semantics - solids, open meshes, etc.
     /// </summary>
-    public class MeshAssembly
+   [Serializable] public class MeshAssembly
     {
         public DMesh3 SourceMesh;
 

--- a/mesh_ops/MeshAutoRepair.cs
+++ b/mesh_ops/MeshAutoRepair.cs
@@ -16,7 +16,7 @@ namespace gs
     ///       - this is tricky, in many CAD meshes these faces can't just be collapsed. But can often remove via flipping...?
     /// 
     /// </summary>
-    public class MeshAutoRepair
+   [Serializable] public class MeshAutoRepair
     {
 		public double RepairTolerance = MathUtil.ZeroTolerancef;
 
@@ -28,7 +28,7 @@ namespace gs
 
 
         // [TODO] interior components?
-        public enum RemoveModes {
+       [Serializable] public enum RemoveModes {
 			None = 0, Interior = 1, Occluded = 2
 		};
 		public RemoveModes RemoveMode = MeshAutoRepair.RemoveModes.None;

--- a/mesh_ops/MeshBoolean.cs
+++ b/mesh_ops/MeshBoolean.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace g3
 {
-    public class MeshBoolean
+   [Serializable] public class MeshBoolean
     {
         public DMesh3 Target;
         public DMesh3 Tool;

--- a/mesh_ops/MeshExtrudeFaces.cs
+++ b/mesh_ops/MeshExtrudeFaces.cs
@@ -16,7 +16,7 @@ namespace g3
     ///      and then connected w/ strip
     ///      [TODO] implement this behavior
     /// </summary>
-    public class MeshExtrudeFaces
+   [Serializable] public class MeshExtrudeFaces
     {
         public DMesh3 Mesh;
         public int[] Triangles;

--- a/mesh_ops/MeshExtrudeLoop.cs
+++ b/mesh_ops/MeshExtrudeLoop.cs
@@ -8,7 +8,7 @@ namespace g3
     /// Operation makes a duplicate loop of vertices, at location defind by PositionF,
     /// then stitches input and new loops together with a ring of triangles.
     /// </summary>
-    public class MeshExtrudeLoop
+   [Serializable] public class MeshExtrudeLoop
     {
         public DMesh3 Mesh;
         public EdgeLoop Loop;

--- a/mesh_ops/MeshExtrudeMesh.cs
+++ b/mesh_ops/MeshExtrudeMesh.cs
@@ -10,7 +10,7 @@ namespace g3
     /// 2) offset copy vertices
     /// 3) connect up loops with triangle strips
     /// </summary>
-    public class MeshExtrudeMesh
+   [Serializable] public class MeshExtrudeMesh
     {
         public DMesh3 Mesh;
 

--- a/mesh_ops/MeshICP.cs
+++ b/mesh_ops/MeshICP.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class MeshICP
+   [Serializable] public class MeshICP
     {
         public IPointSet Source; 
         public DMeshAABBTree3 TargetSurface;

--- a/mesh_ops/MeshInsertPolygon.cs
+++ b/mesh_ops/MeshInsertPolygon.cs
@@ -9,7 +9,7 @@ namespace g3
     /// Inserted edge set is avaliable as .InsertedPolygonEdges, and
     /// triangles inside polygon as .InteriorTriangles
     /// </summary>
-    public class MeshInsertPolygon
+   [Serializable] public class MeshInsertPolygon
     {
         public DMesh3 Mesh;
         public GeneralPolygon2d Polygon;

--- a/mesh_ops/MeshInsertProjectedPolygon.cs
+++ b/mesh_ops/MeshInsertProjectedPolygon.cs
@@ -48,7 +48,7 @@ namespace gs
     /// bary-coords, so that we can compute the new 3D positions. 
     /// 
     /// </summary>
-    public class MeshInsertProjectedPolygon
+   [Serializable] public class MeshInsertProjectedPolygon
     {
         public DMesh3 Mesh;
         public int SeedTriangle = -1;   // you must provide this so that we can efficiently

--- a/mesh_ops/MeshInsertUVPolyCurve.cs
+++ b/mesh_ops/MeshInsertUVPolyCurve.cs
@@ -19,7 +19,7 @@ namespace g3
     ///     preprocess the input mesh to remove degenerate faces/edges
     /// 
     /// </summary>
-    public class MeshInsertUVPolyCurve
+   [Serializable] public class MeshInsertUVPolyCurve
 	{
 		public DMesh3 Mesh;
         public PolyLine2d Curve;

--- a/mesh_ops/MeshIsoCurves.cs
+++ b/mesh_ops/MeshIsoCurves.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class MeshIsoCurves
+   [Serializable] public class MeshIsoCurves
     {
         public DMesh3 Mesh;
         public Func<Vector3d, double> ValueF = null;
@@ -22,7 +22,7 @@ namespace g3
         public bool PrecomputeVertexValues = false;
 
 
-        public enum RootfindingModes { SingleLerp, LerpSteps, Bisection }
+       [Serializable] public enum RootfindingModes { SingleLerp, LerpSteps, Bisection }
 
         /// <summary>
         /// Which rootfinding method will be used to converge on surface along edges
@@ -37,7 +37,7 @@ namespace g3
 
         public DGraph3 Graph = null;
 
-        public enum TriangleCase
+       [Serializable] public enum TriangleCase
         {
             EdgeEdge = 1,
             EdgeVertex = 2,
@@ -51,7 +51,7 @@ namespace g3
         /// mesh_tri is triangle ID of crossed triangle
         /// mesh_edges depends on case. EdgeEdge is [edgeid,edgeid], EdgeVertex is [edgeid,vertexid], and OnEdge is [edgeid,-1]
         /// </summary>
-        public struct GraphEdgeInfo
+        [Serializable] public struct GraphEdgeInfo
         {
             public TriangleCase caseType;
             public int mesh_tri;

--- a/mesh_ops/MeshIterativeSmooth.cs
+++ b/mesh_ops/MeshIterativeSmooth.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public class MeshIterativeSmooth
+   [Serializable] public class MeshIterativeSmooth
     {
         public DMesh3 Mesh;
         public int[] Vertices;

--- a/mesh_ops/MeshLocalParam.cs
+++ b/mesh_ops/MeshLocalParam.cs
@@ -6,12 +6,12 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class MeshLocalParam
+   [Serializable] public class MeshLocalParam
     {
         public static readonly Vector2f InvalidUV = new Vector2f(float.MaxValue, float.MaxValue);
 
 
-        public enum UVModes
+       [Serializable] public enum UVModes
         {
             ExponentialMap,
             ExponentialMap_UpwindAvg,

--- a/mesh_ops/MeshLoopClosure.cs
+++ b/mesh_ops/MeshLoopClosure.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class MeshLoopClosure
+   [Serializable] public class MeshLoopClosure
     {
         public DMesh3 Mesh;
         public EdgeLoop InitialBorderLoop;

--- a/mesh_ops/MeshLoopSmooth.cs
+++ b/mesh_ops/MeshLoopSmooth.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public class MeshLoopSmooth
+   [Serializable] public class MeshLoopSmooth
     {
         public DMesh3 Mesh;
         public EdgeLoop Loop;

--- a/mesh_ops/MeshMeshCut.cs
+++ b/mesh_ops/MeshMeshCut.cs
@@ -17,7 +17,7 @@ namespace g3
     /// 
     /// 
     /// </summary>
-    public class MeshMeshCut
+   [Serializable] public class MeshMeshCut
     {
         public DMesh3 Target;
         public DMesh3 CutMesh;

--- a/mesh_ops/MeshOps.cs
+++ b/mesh_ops/MeshOps.cs
@@ -3,9 +3,9 @@
 namespace g3
 {
 
-    public struct SetGroupBehavior
+    [Serializable] public struct SetGroupBehavior
     {
-        public enum Modes
+       [Serializable] public enum Modes
         {
             Ignore = 0,
             AutoGenerate = 1,

--- a/mesh_ops/MeshPlaneCut.cs
+++ b/mesh_ops/MeshPlaneCut.cs
@@ -23,7 +23,7 @@ namespace g3
 	///   boundary edge tracking...
 	/// 
 	/// </summary>
-	public class MeshPlaneCut
+	[Serializable] public class MeshPlaneCut
 	{
         // Inputs
 		public DMesh3 Mesh;

--- a/mesh_ops/MeshRepairOrientation.cs
+++ b/mesh_ops/MeshRepairOrientation.cs
@@ -8,7 +8,7 @@ using g3;
 
 namespace gs
 {
-	public class MeshRepairOrientation
+	[Serializable] public class MeshRepairOrientation
 	{
 		public DMesh3 Mesh;
 

--- a/mesh_ops/MeshSpatialSort.cs
+++ b/mesh_ops/MeshSpatialSort.cs
@@ -10,7 +10,7 @@ namespace gs
     /// <summary>
     /// This class sorts a set of mesh components.
     /// </summary>
-    public class MeshSpatialSort
+   [Serializable] public class MeshSpatialSort
     {
         // ComponentMesh is a wrapper around input meshes
         public List<ComponentMesh> Components;
@@ -43,7 +43,7 @@ namespace gs
 
 
 
-        public class ComponentMesh
+       [Serializable] public class ComponentMesh
         {
             public object Identifier;
             public DMesh3 Mesh;
@@ -94,7 +94,7 @@ namespace gs
 
 
 
-        public class MeshSolid
+       [Serializable] public class MeshSolid
         {
             public ComponentMesh Outer;
             public List<ComponentMesh> Cavities = new List<ComponentMesh>();

--- a/mesh_ops/MeshStitchLoops.cs
+++ b/mesh_ops/MeshStitchLoops.cs
@@ -19,7 +19,7 @@ namespace gs
     ///      stitching "through" mesh or not. If not set properly, then fill self-intersects.
     ///      Could we (optionally) resolve this automatically, eg by checking total of the two alternatives?
     /// </summary>
-    public class MeshStitchLoops
+   [Serializable] public class MeshStitchLoops
     {
         public DMesh3 Mesh;
         public EdgeLoop Loop0;

--- a/mesh_ops/MeshTopology.cs
+++ b/mesh_ops/MeshTopology.cs
@@ -16,7 +16,7 @@ namespace gs
     /// WIP
     /// 
     /// </summary>
-    public class MeshTopology
+   [Serializable] public class MeshTopology
     {
         public DMesh3 Mesh;
 

--- a/mesh_ops/MeshTrimLoop.cs
+++ b/mesh_ops/MeshTrimLoop.cs
@@ -25,7 +25,7 @@ namespace g3
     /// - output boundary EdgeLoop that has been aligned w/ trim curve
     /// - handle cases where input mesh has open borders
     /// </summary>
-    public class MeshTrimLoop
+   [Serializable] public class MeshTrimLoop
 	{
 		public DMesh3 Mesh;
         public DMeshAABBTree3 Spatial;

--- a/mesh_ops/MinimalHoleFill.cs
+++ b/mesh_ops/MinimalHoleFill.cs
@@ -13,7 +13,7 @@ namespace gs
     /// is often quasi-developable, reconstructs sharp edges, etc. 
     /// There are various options.
     /// </summary>
-    public class MinimalHoleFill
+   [Serializable] public class MinimalHoleFill
     {
         public DMesh3 Mesh;
         public EdgeLoop FillLoop;

--- a/mesh_ops/PlanarHoleFiller.cs
+++ b/mesh_ops/PlanarHoleFiller.cs
@@ -23,7 +23,7 @@ namespace g3
     /// not be stitched.
     /// 
     /// </summary>
-    public class PlanarHoleFiller
+   [Serializable] public class PlanarHoleFiller
     {
         public DMesh3 Mesh;
 

--- a/mesh_ops/PlanarSpansFiller.cs
+++ b/mesh_ops/PlanarSpansFiller.cs
@@ -20,7 +20,7 @@ namespace g3
     ///   
     /// 
     /// </summary>
-    public class PlanarSpansFiller
+   [Serializable] public class PlanarSpansFiller
     {
         public DMesh3 Mesh;
 

--- a/mesh_ops/RegionOperator.cs
+++ b/mesh_ops/RegionOperator.cs
@@ -14,7 +14,7 @@ namespace g3
     ///   trying to guess it here, by making some assumptions about what happens. It works for now, but
     ///   it would better if MeshEditor returned this information.
     /// </summary>
-    public class RegionOperator
+   [Serializable] public class RegionOperator
     {
         public DMesh3 BaseMesh;
         public DSubmesh3 Region;

--- a/mesh_ops/RemoveDuplicateTriangles.cs
+++ b/mesh_ops/RemoveDuplicateTriangles.cs
@@ -9,7 +9,7 @@ namespace gs
 	/// <summary>
 	/// Remove duplicate triangles.
 	/// </summary>
-	public class RemoveDuplicateTriangles
+	[Serializable] public class RemoveDuplicateTriangles
 	{
 		public DMesh3 Mesh;
 

--- a/mesh_ops/RemoveOccludedTriangles.cs
+++ b/mesh_ops/RemoveOccludedTriangles.cs
@@ -14,7 +14,7 @@ namespace gs
     /// something akin to ambient occlusion, and if face is fully occluded, then
     /// we classify it as inside and remove it.
 	/// </summary>
-	public class RemoveOccludedTriangles
+	[Serializable] public class RemoveOccludedTriangles
 	{
 		public DMesh3 Mesh;
         public DMeshAABBTree3 Spatial;
@@ -35,7 +35,7 @@ namespace gs
         // use this as winding isovalue for WindingNumber mode
         public double WindingIsoValue = 0.5;
 
-        public enum CalculationMode
+       [Serializable] public enum CalculationMode
         {
             RayParity = 0,
             AnalyticWindingNumber = 1,

--- a/mesh_ops/SimpleHoleFiller.cs
+++ b/mesh_ops/SimpleHoleFiller.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class SimpleHoleFiller
+   [Serializable] public class SimpleHoleFiller
     {
         public DMesh3 Mesh;
         public EdgeLoop Loop;

--- a/mesh_ops/SmoothedHoleFill.cs
+++ b/mesh_ops/SmoothedHoleFill.cs
@@ -12,7 +12,7 @@ namespace gs
     /// This fills a hole in a mesh by doing a trivial fill, optionally offsetting along a fixed vector,
     /// then doing a remesh, then a laplacian smooth, then a second remesh.
     /// </summary>
-    public class SmoothedHoleFill
+   [Serializable] public class SmoothedHoleFill
     {
         public DMesh3 Mesh;
 

--- a/mesh_selection/MeshBoundaryLoops.cs
+++ b/mesh_selection/MeshBoundaryLoops.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-	public class MeshBoundaryLoopsException : Exception
+	[Serializable] public class MeshBoundaryLoopsException : Exception
 	{
 		public MeshBoundaryLoopsException(string message) : base(message) {}
 		public bool UnclosedLoop = false;
@@ -18,7 +18,7 @@ namespace g3
 	/// Extract boundary EdgeLoops from Mesh. Can also extract EdgeSpans for open areas,
     /// however default behavior is to ignore these. Set .SpanBehavior to configure.
 	/// </summary>
-    public class MeshBoundaryLoops : IEnumerable<EdgeLoop>
+   [Serializable] public class MeshBoundaryLoops : IEnumerable<EdgeLoop>
     {
         public DMesh3 Mesh;
         public List<EdgeLoop> Loops;
@@ -30,14 +30,14 @@ namespace g3
 
         // What should we do if we encounter open spans. Mainly a result of EdgeFilter, but can also
         // happen on meshes w/ crazy bowties
-        public enum SpanBehaviors
+       [Serializable] public enum SpanBehaviors
         {
             Ignore, ThrowException, Compute
         };
         public SpanBehaviors SpanBehavior = SpanBehaviors.Compute;
 
         // What should we do if we encounter an unrecoverable failure while walking a loop
-        public enum FailureBehaviors
+       [Serializable] public enum FailureBehaviors
         {
             ThrowException,       // die, and you clean up
             ConvertToOpenSpan     // keep un-closed loop as a span

--- a/mesh_selection/MeshConnectedComponents.cs
+++ b/mesh_selection/MeshConnectedComponents.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public class MeshConnectedComponents : IEnumerable<MeshConnectedComponents.Component>
+   [Serializable] public class MeshConnectedComponents : IEnumerable<MeshConnectedComponents.Component>
     {
         public DMesh3 Mesh;
 
@@ -18,7 +18,7 @@ namespace g3
         // (or don't know) a full-triangle-set filter
         public Func<int, bool> SeedFilterF = null;
 
-        public struct Component
+        [Serializable] public struct Component
         {
             public int[] Indices;
         }

--- a/mesh_selection/MeshEdgeSelection.cs
+++ b/mesh_selection/MeshEdgeSelection.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class MeshEdgeSelection : IEnumerable<int>
+   [Serializable] public class MeshEdgeSelection : IEnumerable<int>
     {
         public DMesh3 Mesh;
 

--- a/mesh_selection/MeshFaceSelection.cs
+++ b/mesh_selection/MeshFaceSelection.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class MeshFaceSelection : IEnumerable<int>
+   [Serializable] public class MeshFaceSelection : IEnumerable<int>
     {
         public DMesh3 Mesh;
 

--- a/mesh_selection/MeshFacesFromLoop.cs
+++ b/mesh_selection/MeshFacesFromLoop.cs
@@ -10,7 +10,7 @@ namespace g3
     /// If a seed triangle in the enclosed region is not provided, then the
     /// smaller of the two largest connected-components is chosen as the "inside".
     /// </summary>
-    public class MeshFacesFromLoop
+   [Serializable] public class MeshFacesFromLoop
     {
         public DMesh3 Mesh;
 

--- a/mesh_selection/MeshRegionBoundaryLoops.cs
+++ b/mesh_selection/MeshRegionBoundaryLoops.cs
@@ -11,7 +11,7 @@ namespace g3
 	/// <summary>
 	/// Extract boundary EdgeLoops for subregions of Mesh
 	/// </summary>
-    public class MeshRegionBoundaryLoops : IEnumerable<EdgeLoop>
+   [Serializable] public class MeshRegionBoundaryLoops : IEnumerable<EdgeLoop>
     {
         public DMesh3 Mesh;
         public List<EdgeLoop> Loops;

--- a/mesh_selection/MeshVertexSelection.cs
+++ b/mesh_selection/MeshVertexSelection.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace g3
 {
-    public class MeshVertexSelection : IEnumerable<int>
+   [Serializable] public class MeshVertexSelection : IEnumerable<int>
     {
         public DMesh3 Mesh;
 

--- a/queries/IntersectionUtil.cs
+++ b/queries/IntersectionUtil.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public enum IntersectionResult
+   [Serializable] public enum IntersectionResult
     {
         NotComputed,
         Intersects,
@@ -13,7 +13,7 @@ namespace g3
 		InvalidQuery
     }
 
-    public enum IntersectionType
+   [Serializable] public enum IntersectionType
     {
         Empty, Point, Segment, Line, Polygon, Plane, Unknown
     }
@@ -21,7 +21,7 @@ namespace g3
     /// <summary>
     /// returned by linear-primitive intersection functions
     /// </summary>
-    public struct LinearIntersection
+    [Serializable] public struct LinearIntersection
     {
         public bool intersects;
         public int numIntersections;       // 0, 1, or 2

--- a/queries/MeshValidation.cs
+++ b/queries/MeshValidation.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace g3
 {
-    public enum ValidationStatus
+   [Serializable] public enum ValidationStatus
     {
         Ok,
 

--- a/queries/RayIntersection.cs
+++ b/queries/RayIntersection.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class RayIntersection
+   [Serializable] public class RayIntersection
     {
         private RayIntersection()
         {

--- a/shapes3/Circle3.cs
+++ b/shapes3/Circle3.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // somewhat ported from WildMagic5
-    public class Circle3d
+   [Serializable] public class Circle3d
     {
         // The plane containing the circle is Dot(N,X-C) = 0, where X is any point
         // in the plane.  Vectors U, V, and N form an orthonormal right-handed set

--- a/shapes3/Cylinder3.cs
+++ b/shapes3/Cylinder3.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // ported from GTEngine (WildMagic5 doesn't have cylinder primitive)
-    public class Cylinder3d
+   [Serializable] public class Cylinder3d
     {
         // The cylinder axis is a line.  The origin of the cylinder is chosen to be
         // the line origin.  The cylinder wall is at a distance R units from the axis.

--- a/solvers/CholeskyDecomposition.cs
+++ b/solvers/CholeskyDecomposition.cs
@@ -14,7 +14,7 @@ namespace g3
 	/// 
 	/// 
 	/// </summary>
-    public class CholeskyDecomposition
+   [Serializable] public class CholeskyDecomposition
     {
 		public DenseMatrix A;
 

--- a/solvers/DenseMatrix.cs
+++ b/solvers/DenseMatrix.cs
@@ -6,7 +6,7 @@ namespace g3
 	/// <summary>
 	/// Row-major dense matrix
 	/// </summary>
-    public class DenseMatrix : IMatrix
+   [Serializable] public class DenseMatrix : IMatrix
     {
         double[] d;
 		int N;		// rows

--- a/solvers/DenseVector.cs
+++ b/solvers/DenseVector.cs
@@ -2,7 +2,7 @@
 
 namespace g3
 {
-    public class DenseVector
+   [Serializable] public class DenseVector
     {
         double[] d;
         int N;

--- a/solvers/FastQuaternionSVD.cs
+++ b/solvers/FastQuaternionSVD.cs
@@ -28,7 +28,7 @@ namespace g3
     ///   - SymmetricMatrix3d currently a class, could make a struct (see comments)
     /// 
     /// </summary>
-    public class FastQuaternionSVD
+   [Serializable] public class FastQuaternionSVD
     {
         int NumJacobiIterations = 4;   // increase this to get higher accuracy
                                        // TODO: characterize...

--- a/solvers/PackedSparseMatrix.cs
+++ b/solvers/PackedSparseMatrix.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace g3
 {
-    public struct matrix_entry
+    [Serializable] public struct matrix_entry
     {
         public int r;
         public int c;
@@ -18,9 +18,9 @@ namespace g3
     /// This is a sparse matrix where each row is an array of (column,value) pairs
     /// This is more efficient for Matrix*Vector multiply.
     /// </summary>
-    public class PackedSparseMatrix
+   [Serializable] public class PackedSparseMatrix
     {
-        public struct nonzero
+        [Serializable] public struct nonzero
         {
             public int j;
             public double d;
@@ -31,7 +31,7 @@ namespace g3
         public bool Sorted = false;
         public int NumNonZeros = 0;
 
-        public enum StorageModes
+       [Serializable] public enum StorageModes
         {
             Full
         }

--- a/solvers/SingularValueDecomposition.cs
+++ b/solvers/SingularValueDecomposition.cs
@@ -20,7 +20,7 @@ namespace g3
     ///          if ( det(V) == -1 ) { V *= -1; S *= -1 }     (right? seems to work)
     ///  
     /// </summary>
-    public class SingularValueDecomposition
+   [Serializable] public class SingularValueDecomposition
     {
         // port of WildMagic5 SingularValueDecomposition class (which is a back-port
         // of GTEngine SVD class) see geometrictools.com

--- a/solvers/SparseMatrix.cs
+++ b/solvers/SparseMatrix.cs
@@ -12,7 +12,7 @@ namespace g3
     /// Uses Dictionary as sparsifying data structure, which is probably
     /// not a good option. But it is easy.
     /// </summary>
-    public class SymmetricSparseMatrix : IMatrix
+   [Serializable] public class SymmetricSparseMatrix : IMatrix
     {
         Dictionary<Index2i, double> d = new Dictionary<Index2i, double>();
         int N;
@@ -310,7 +310,7 @@ namespace g3
 
 
 
-    public class DiagonalMatrix
+   [Serializable] public class DiagonalMatrix
     {
         public double[] D;
 

--- a/solvers/SparseSymmetricCG.cs
+++ b/solvers/SparseSymmetricCG.cs
@@ -3,7 +3,7 @@
 namespace g3
 {
     // ported from WildMagic5 Wm5LinearSystem.cpp
-    public class SparseSymmetricCG
+   [Serializable] public class SparseSymmetricCG
     {
         // Compute B = A*X, where inputs are ordered <X,B>
         public Action<double[], double[]> MultiplyF;
@@ -223,7 +223,7 @@ namespace g3
     /// converged, however we still have to do the multiplies!
     /// 
     /// </summary>
-    public class SparseSymmetricCGMultipleRHS
+   [Serializable] public class SparseSymmetricCGMultipleRHS
     {
         // Compute B = A*X, where inputs are ordered <X,B>
         public Action<double[][], double[][]> MultiplyF;

--- a/solvers/SymmetricEigenSolver.cs
+++ b/solvers/SymmetricEigenSolver.cs
@@ -38,7 +38,7 @@ namespace g3
     // vectors in the lower-triangular portion of the matrix to save memory.  The
     // implementation uses both suggestions.
 
-    public class SymmetricEigenSolver
+   [Serializable] public class SymmetricEigenSolver
     {
         // The solver processes NxN symmetric matrices, where N > 1 ('size' is N)
         // and the matrix is stored in row-major order.  The maximum number of
@@ -70,7 +70,7 @@ namespace g3
         // ordered accordingly.  The return value is the number of iterations
         // consumed when convergence occurred, 0xFFFFFFFF when convergence did
         // not occur, or 0 when N <= 1 was passed to the constructor.
-        public enum SortType
+       [Serializable] public enum SortType
         {
             Decreasing = -1,
             NoSorting = 0,

--- a/spatial/BasicIntersectionTargets.cs
+++ b/spatial/BasicIntersectionTargets.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace g3
 {
 
-    public class TransformedIntersectionTarget : IIntersectionTarget
+   [Serializable] public class TransformedIntersectionTarget : IIntersectionTarget
     {
         DMeshIntersectionTarget BaseTarget = null;
 
@@ -32,7 +32,7 @@ namespace g3
 
 
 
-    public class DMeshIntersectionTarget : IIntersectionTarget
+   [Serializable] public class DMeshIntersectionTarget : IIntersectionTarget
     {
         public DMesh3 Mesh { get; set; }
         public ISpatial Spatial { get; set; }
@@ -69,7 +69,7 @@ namespace g3
     /// <summary>
     /// Compute ray-intersection with plane
     /// </summary>
-    public class PlaneIntersectionTarget : IIntersectionTarget
+   [Serializable] public class PlaneIntersectionTarget : IIntersectionTarget
     {
         public Frame3f PlaneFrame;
         public int NormalAxis = 2;

--- a/spatial/BasicProjectionTargets.cs
+++ b/spatial/BasicProjectionTargets.cs
@@ -9,7 +9,7 @@ namespace g3
     /// MeshProjectionTarget provides an IProjectionTarget interface to a mesh + spatial data structure.
     /// Use to project points to mesh surface.
     /// </summary>
-    public class MeshProjectionTarget : IOrientedProjectionTarget
+   [Serializable] public class MeshProjectionTarget : IOrientedProjectionTarget
     {
         public DMesh3 Mesh { get; set; }
         public ISpatial Spatial { get; set; }
@@ -82,7 +82,7 @@ namespace g3
     /// Extension of MeshProjectionTarget that allows the target to have a transformation
     /// relative to it's internal space. Call SetTransform(), or initialize the transforms yourself
     /// </summary>
-    public class TransformedMeshProjectionTarget : MeshProjectionTarget
+   [Serializable] public class TransformedMeshProjectionTarget : MeshProjectionTarget
     {
         public TransformSequence SourceToTargetXForm;
         public TransformSequence TargetToSourceXForm;
@@ -127,7 +127,7 @@ namespace g3
 
 
 
-    public class PlaneProjectionTarget : IProjectionTarget
+   [Serializable] public class PlaneProjectionTarget : IProjectionTarget
     {
         public Vector3d Origin;
         public Vector3d Normal;
@@ -142,7 +142,7 @@ namespace g3
 
 
 
-    public class CircleProjectionTarget : IProjectionTarget
+   [Serializable] public class CircleProjectionTarget : IProjectionTarget
     {
         public Circle3d Circle;
 
@@ -156,7 +156,7 @@ namespace g3
 
 
 
-    public class CylinderProjectionTarget : IProjectionTarget
+   [Serializable] public class CylinderProjectionTarget : IProjectionTarget
     {
         public Cylinder3d Cylinder;
 
@@ -171,7 +171,7 @@ namespace g3
 
 
 
-    public class SequentialProjectionTarget : IProjectionTarget
+   [Serializable] public class SequentialProjectionTarget : IProjectionTarget
     {
         public IProjectionTarget[] Targets { get; set; }
 

--- a/spatial/BiGrid3.cs
+++ b/spatial/BiGrid3.cs
@@ -11,7 +11,7 @@ namespace g3
     /// automatically generates necessary data structures. 
     /// Functions to act on parent/child grids are in-progress...
     /// </summary>
-    public class BiGrid3<BlockType> where BlockType : class, IGridElement3, IFixedGrid3
+   [Serializable] public class BiGrid3<BlockType> where BlockType : class, IGridElement3, IFixedGrid3
     {
         Vector3i block_size;
         MultigridIndexer3 indexer;

--- a/spatial/Bitmap2.cs
+++ b/spatial/Bitmap2.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace g3
 {
 
-    public class Bitmap2
+   [Serializable] public class Bitmap2
     {
         public BitArray Bits;
 

--- a/spatial/Bitmap3.cs
+++ b/spatial/Bitmap3.cs
@@ -14,7 +14,7 @@ namespace g3
 
 
 
-    public class Bitmap3 : IBinaryVoxelGrid, IGridElement3, IFixedGrid3
+   [Serializable] public class Bitmap3 : IBinaryVoxelGrid, IGridElement3, IFixedGrid3
     {
         public BitArray Bits;
 

--- a/spatial/DCurveBoxTree.cs
+++ b/spatial/DCurveBoxTree.cs
@@ -14,7 +14,7 @@ namespace g3
     /// [TODO] would it make more sense to have more than just 2 segments at lowest level?
     /// 
     /// </summary>
-    public class DCurve3BoxTree
+   [Serializable] public class DCurve3BoxTree
     {
         public DCurve3 Curve;
 

--- a/spatial/DCurveProjection.cs
+++ b/spatial/DCurveProjection.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace g3
 {
-    public class DCurveProjectionTarget : IProjectionTarget
+   [Serializable] public class DCurveProjectionTarget : IProjectionTarget
     {
         public DCurve3 Curve;
 

--- a/spatial/DMeshAABBTree.cs
+++ b/spatial/DMeshAABBTree.cs
@@ -29,7 +29,7 @@ namespace g3
     ///   - DoTraversal(generic_traversal_object)
     /// 
     /// </summary>
-    public class DMeshAABBTree3 : ISpatial
+   [Serializable] public class DMeshAABBTree3 : ISpatial
     {
         protected DMesh3 mesh;
         protected int mesh_timestamp;
@@ -63,7 +63,7 @@ namespace g3
 
 
         // how should we build the tree?
-        public enum BuildStrategy
+       [Serializable] public enum BuildStrategy
         {
             Default,                // currently TopDownMidpoint
 
@@ -78,7 +78,7 @@ namespace g3
                                     //   2-4x slower than TopDownMidpoint, but trees are generally more efficient and balanced.
         }
 
-        public enum ClusterPolicy
+       [Serializable] public enum ClusterPolicy
         {
             Default,               // currently FastVolumeMetric
             Fastest,               // sort list and then just cluster sequential boxes. 
@@ -651,17 +651,17 @@ namespace g3
 
 
 
-        public struct PointIntersection
+        [Serializable] public struct PointIntersection
         {
             public int t0, t1;
             public Vector3d point;
         }
-        public struct SegmentIntersection
+        [Serializable] public struct SegmentIntersection
         {
             public int t0, t1;
             public Vector3d point0, point1;
         }
-        public class IntersectionsQueryResult
+       [Serializable] public class IntersectionsQueryResult
         {
             public List<PointIntersection> Points;
             public List<SegmentIntersection> Segments;
@@ -1001,7 +1001,7 @@ namespace g3
         /// that branch of the traversal, or true to descend into that box's children (boxes or triangles).
         /// NextTriangleF() is called for each triangle.
         /// </summary>
-        public class TreeTraversal
+       [Serializable] public class TreeTraversal
         {
             // return false to terminate this branch
             // arguments are box and depth in tree

--- a/spatial/DSparseGrid3.cs
+++ b/spatial/DSparseGrid3.cs
@@ -45,7 +45,7 @@ namespace g3
     /// This can be used to implement multi-grid schemes, eg for example the GridElement
     /// type could be Bitmap3 of a fixed dimension.
     /// </summary>
-    public class DSparseGrid3<ElemType> : IGrid3 where ElemType : class, IGridElement3
+   [Serializable] public class DSparseGrid3<ElemType> : IGrid3 where ElemType : class, IGridElement3
     {
         ElemType exemplar;
 

--- a/spatial/DenseGrid2.cs
+++ b/spatial/DenseGrid2.cs
@@ -10,7 +10,7 @@ namespace g3
     /// <summary>
     /// 2D dense grid of floating-point scalar values. 
     /// </summary>
-    public class DenseGrid2f
+   [Serializable] public class DenseGrid2f
     {
         public float[] Buffer;
         public int ni, nj;
@@ -160,7 +160,7 @@ namespace g3
     /// <summary>
     /// 2D dense grid of integers. 
     /// </summary>
-    public class DenseGrid2i
+   [Serializable] public class DenseGrid2i
     {
         public int[] Buffer;
         public int ni, nj;

--- a/spatial/DenseGrid3.cs
+++ b/spatial/DenseGrid3.cs
@@ -9,7 +9,7 @@ namespace g3
     /// <summary>
     /// 3D dense grid of floating-point scalar values. 
     /// </summary>
-    public class DenseGrid3f
+   [Serializable] public class DenseGrid3f
     {
         public float[] Buffer;
         public int ni, nj, nk;
@@ -209,7 +209,7 @@ namespace g3
     /// <summary>
     /// 3D dense grid of integers. 
     /// </summary>
-    public class DenseGrid3i
+   [Serializable] public class DenseGrid3i
     {
         public int[] Buffer;
         public int ni, nj, nk;

--- a/spatial/EditMeshSpatial.cs
+++ b/spatial/EditMeshSpatial.cs
@@ -13,7 +13,7 @@ namespace gs
     /// For use case where we are making local edits to a source mesh. We mask out
     /// removed triangles from base mesh SpatialDS, and raycast new triangles separately.
     /// </summary>
-    public class EditMeshSpatial : ISpatial
+   [Serializable] public class EditMeshSpatial : ISpatial
     {
         public DMesh3 SourceMesh;
         public DMeshAABBTree3 SourceSpatial;

--- a/spatial/GridIndexing.cs
+++ b/spatial/GridIndexing.cs
@@ -24,7 +24,7 @@ namespace g3
 
 
 
-    public struct GridLevelIndex
+    [Serializable] public struct GridLevelIndex
     {
         public Vector3i block_index;
         public Vector3i local_index;
@@ -66,7 +66,7 @@ namespace g3
 	/// <summary>
 	/// Map to/from grid coords
 	/// </summary>
-	public struct ScaleGridIndexer3 : IGridWorldIndexer3
+	[Serializable] public struct ScaleGridIndexer3 : IGridWorldIndexer3
 	{
 		public double CellSize;
 
@@ -109,7 +109,7 @@ namespace g3
 	/// <summary>
 	/// Map to/from grid coords, where grid is translated from origin
 	/// </summary>
-	public struct ShiftGridIndexer3 : IGridWorldIndexer3
+	[Serializable] public struct ShiftGridIndexer3 : IGridWorldIndexer3
 	{
 		public Vector3d Origin;
 		public double CellSize;
@@ -154,7 +154,7 @@ namespace g3
     /// <summary>
     /// Map to/from grid coords, where grid is relative to frame coords/axes
     /// </summary>
-    public struct FrameGridIndexer3 : IGridWorldIndexer3
+    [Serializable] public struct FrameGridIndexer3 : IGridWorldIndexer3
     {
         public Frame3f GridFrame;
         public Vector3f CellSize;
@@ -197,7 +197,7 @@ namespace g3
     /// map between "outer" (ie higher-res) grid coordinates and 
     /// "blocks" of those coordinates.
     /// </summary>
-    public struct MultigridIndexer3 : IMultigridIndexer3
+    [Serializable] public struct MultigridIndexer3 : IMultigridIndexer3
     {
         public Vector3i OuterShift;
         public Vector3i BlockSize;

--- a/spatial/GridIndexing2.cs
+++ b/spatial/GridIndexing2.cs
@@ -21,7 +21,7 @@ namespace g3
 
 
 
-    public struct GridLevelIndex2
+    [Serializable] public struct GridLevelIndex2
     {
         public Vector2i block_index;
         public Vector2i local_index;
@@ -63,7 +63,7 @@ namespace g3
 	/// <summary>
 	/// Map to/from grid coords
 	/// </summary>
-	public struct ScaleGridIndexer2 : IGridWorldIndexer2
+	[Serializable] public struct ScaleGridIndexer2 : IGridWorldIndexer2
 	{
 		public double CellSize;
 
@@ -96,7 +96,7 @@ namespace g3
 	/// <summary>
 	/// Map to/from grid coords, where grid is translated from origin
 	/// </summary>
-	public struct ShiftGridIndexer2 : IGridWorldIndexer2
+	[Serializable] public struct ShiftGridIndexer2 : IGridWorldIndexer2
 	{
 		public Vector2d Origin;
 		public double CellSize;
@@ -131,7 +131,7 @@ namespace g3
     /// map between "outer" (ie higher-res) grid coordinates and 
     /// "blocks" of those coordinates.
     /// </summary>
-    public struct MultigridIndexer2 : IMultigridIndexer2
+    [Serializable] public struct MultigridIndexer2 : IMultigridIndexer2
     {
         public Vector2i OuterShift;
         public Vector2i BlockSize;

--- a/spatial/MeshScalarSamplingGrid.cs
+++ b/spatial/MeshScalarSamplingGrid.cs
@@ -21,7 +21,7 @@ namespace gs
     ///     are keeping track of active edges instead of active cells?
     /// 
     /// </summary>
-    public class MeshScalarSamplingGrid
+   [Serializable] public class MeshScalarSamplingGrid
     {
         public DMesh3 Mesh;
         public Func<Vector3d, double> ScalarF;
@@ -34,7 +34,7 @@ namespace gs
 
         // Should we compute values at all grid cells (expensive!!) or only in narrow band.
         // In narrow-band mode, we guess rest of values by propagating along x-rows
-        public enum ComputeModes
+       [Serializable] public enum ComputeModes
         {
             FullGrid = 0,
             NarrowBand = 1

--- a/spatial/MeshSignedDistanceGrid.cs
+++ b/spatial/MeshSignedDistanceGrid.cs
@@ -37,7 +37,7 @@ namespace g3
     /// Original license was public domain. 
     /// Permission granted by Christopher Batty to include C# port under Boost license.
     /// </summary>
-    public class MeshSignedDistanceGrid
+   [Serializable] public class MeshSignedDistanceGrid
     {
         public DMesh3 Mesh;
         public DMeshAABBTree3 Spatial;
@@ -58,7 +58,7 @@ namespace g3
         // Can also fill in the rest of the full grid with fast sweeping. This is 
         // quite computationally intensive, though, and not parallelizable 
         // (time only depends on grid resolution)
-        public enum ComputeModes
+       [Serializable] public enum ComputeModes
         {
             FullGrid = 0,
             NarrowBandOnly = 1,
@@ -80,7 +80,7 @@ namespace g3
         // Parity count is basically mesh winding number, handles overlap shells and
         // self-intersections, but inverted shells are 'subtracted', and inverted faces are a disaster.
         // Both modes handle internal cavities, neither handles open sheets.
-        public enum InsideModes
+       [Serializable] public enum InsideModes
         {
             CrossingCount = 0,
             ParityCount = 1

--- a/spatial/MeshWindingNumberGrid.cs
+++ b/spatial/MeshWindingNumberGrid.cs
@@ -21,7 +21,7 @@ namespace gs
     ///     are keeping track of active edges instead of active cells?
     /// 
     /// </summary>
-    public class MeshWindingNumberGrid
+   [Serializable] public class MeshWindingNumberGrid
     {
         public DMesh3 Mesh;
         public DMeshAABBTree3 MeshSpatial;
@@ -34,7 +34,7 @@ namespace gs
 
         // Should we compute MWN at all grid cells (expensive!!) or only in narrow band.
         // In narrow-band mode, we guess rest of MWN values by propagating along x-rows
-        public enum ComputeModes
+       [Serializable] public enum ComputeModes
         {
             FullGrid = 0,
             NarrowBand = 1

--- a/spatial/NormalHistogram.cs
+++ b/spatial/NormalHistogram.cs
@@ -9,7 +9,7 @@ namespace g3
     /// Construct spherical histogram of normals of mesh. 
     /// Binning is done using a Spherical Fibonacci point set.
     /// </summary>
-    public class NormalHistogram
+   [Serializable] public class NormalHistogram
     {
         public int Bins = 1024;
         public SphericalFibonacciPointSet Points;

--- a/spatial/PointAABBTree3.cs
+++ b/spatial/PointAABBTree3.cs
@@ -13,7 +13,7 @@ namespace g3
     /// TODO: no timestamp support right now...
     /// 
     /// </summary>
-    public class PointAABBTree3
+   [Serializable] public class PointAABBTree3
     {
         IPointSet points;
         int points_timestamp;
@@ -38,7 +38,7 @@ namespace g3
         public int LeafMaxPointCount = 32;
 
         // how should we build the tree?
-        public enum BuildStrategy
+       [Serializable] public enum BuildStrategy
         {
             Default,                // currently TopDownMidpoint
 
@@ -136,7 +136,7 @@ namespace g3
         /// that branch of the traversal, or true to descend into that box's children (boxes or points).
         /// NextPointF() is called for each point.
         /// </summary>
-        public class TreeTraversal
+       [Serializable] public class TreeTraversal
         {
             // return false to terminate this branch
             // arguments are box and depth in tree

--- a/spatial/PointHashGrid2d.cs
+++ b/spatial/PointHashGrid2d.cs
@@ -15,7 +15,7 @@ namespace g3
     /// you must also know it's 2D coordinate, so we can look up the cell coordinates.
     /// Hence, to 'update' a point, you need to know both it's old and new 2D coordinates.
     /// </summary>
-    public class PointHashGrid2d<T>
+   [Serializable] public class PointHashGrid2d<T>
     {
         Dictionary<Vector2i, List<T>> Hash;
         ScaleGridIndexer2 Indexer;

--- a/spatial/PointHashGrid3d.cs
+++ b/spatial/PointHashGrid3d.cs
@@ -20,7 +20,7 @@ namespace g3
     /// big, we build a sub-hash there?
     /// 
     /// </summary>
-    public class PointHashGrid3d<T>
+   [Serializable] public class PointHashGrid3d<T>
     {
         Dictionary<Vector3i, List<T>> Hash;
         ScaleGridIndexer3 Indexer;

--- a/spatial/PointSetHashtable.cs
+++ b/spatial/PointSetHashtable.cs
@@ -6,7 +6,7 @@ using g3;
 
 namespace gs
 {
-	public class PointSetHashtable
+	[Serializable] public class PointSetHashtable
 	{
 		IPointSet Points;
 		DSparseGrid3<PointList> Grid;
@@ -104,7 +104,7 @@ namespace gs
 
 
 
-		public class PointList : List<int>, IGridElement3 {
+		[Serializable] public class PointList : List<int>, IGridElement3 {
 			public IGridElement3 CreateNewGridElement(bool bCopy) {
 				return new PointList();
 			}

--- a/spatial/Polygon2dBoxTree.cs
+++ b/spatial/Polygon2dBoxTree.cs
@@ -7,7 +7,7 @@ namespace g3
 {
 
 
-    public class GeneralPolygon2dBoxTree
+   [Serializable] public class GeneralPolygon2dBoxTree
     {
         public GeneralPolygon2d Polygon;
 
@@ -81,7 +81,7 @@ namespace g3
     /// [TODO] would it make more sense to have more than just 2 segments at lowest level?
     /// 
     /// </summary>
-    public class Polygon2dBoxTree
+   [Serializable] public class Polygon2dBoxTree
     {
         public Polygon2d Polygon;
 

--- a/spatial/SegmentHashGrid.cs
+++ b/spatial/SegmentHashGrid.cs
@@ -22,7 +22,7 @@ namespace g3
     /// you must also know it's 2D center, so we can look up the cell coordinates.
     /// Hence, to 'update' a segment, you need to know both it's old and new 2D centers.
     /// </summary>
-    public class SegmentHashGrid2d<T>
+   [Serializable] public class SegmentHashGrid2d<T>
     {
         Dictionary<Vector2i, List<T>> Hash;
         ScaleGridIndexer2 Indexer;

--- a/spatial/SegmentSet2d.cs
+++ b/spatial/SegmentSet2d.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace g3
 {
 	// [TODO] some kind of spatial sorting!!
-	public class SegmentSet2d
+	[Serializable] public class SegmentSet2d
 	{
 		List<Segment2d> Segments;
 

--- a/spatial/SpatialFunctions.cs
+++ b/spatial/SpatialFunctions.cs
@@ -14,7 +14,7 @@ namespace g3
         // various offset-surface functions, in class so the compute functions 
         // can be passed to other functions
         [System.Obsolete("NormalOffset is deprecated - is anybody using it? please lmk.")]
-        public class NormalOffset
+       [Serializable] public class NormalOffset
         {
             public DMesh3 Mesh;
             public ISpatial Spatial;

--- a/spatial/TriangleBinsGrid2d.cs
+++ b/spatial/TriangleBinsGrid2d.cs
@@ -20,7 +20,7 @@ namespace g3
     /// overlaps. Need conservative rasterization to improve this. Can implement by
     /// testing each bin bbox for intersection w/ triangle
     /// </summary>
-    public class TriangleBinsGrid2d
+   [Serializable] public class TriangleBinsGrid2d
     {
         ShiftGridIndexer2 indexer;
         AxisAlignedBox2d bounds;


### PR DESCRIPTION
…naryFormatter serialization

geometry3Sharp is popular and been used in many projects. most projects has their own objects where geometry3Sharp objects are being used and in modern applications cloning/caching/serialization is very common. C#.Net's native BinaryFormatter is fastest way of serializing big objects which you can only do with the objects decorated using [Serializable] attribute. And also the own project classes are not BinaryFormatter serializable if geometry3Sharp objects are used in it. This change will help many projects.